### PR TITLE
Fix CI formatting issues

### DIFF
--- a/internal/entities/character.go
+++ b/internal/entities/character.go
@@ -94,11 +94,11 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 		if weap, ok := c.EquippedSlots[SlotMainHand].(*Weapon); ok {
 			log.Printf("Main hand weapon found: %s", weap.GetName())
 			attacks := make([]*attack.Result, 0)
-			
+
 			// Check proficiency while we have the mutex
 			isProficient := c.hasWeaponProficiencyInternal(weap.GetKey())
 			log.Printf("Weapon proficiency check: %v", isProficient)
-			
+
 			// Calculate ability bonus based on weapon type
 			var abilityBonus int
 			switch weap.WeaponRange {
@@ -107,16 +107,16 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 			case "Melee":
 				abilityBonus = c.Attributes[AttributeStrength].Bonus
 			}
-			
+
 			// Calculate proficiency bonus if proficient
 			proficiencyBonus := 0
 			if isProficient {
 				proficiencyBonus = 2 + ((c.Level - 1) / 4)
 			}
-			
+
 			attackBonus := abilityBonus + proficiencyBonus
 			damageBonus := abilityBonus // Only ability modifier applies to damage
-			
+
 			// Roll the attack
 			var attak1 *attack.Result
 			var err error
@@ -125,7 +125,7 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 			} else {
 				attak1, err = attack.RollAttack(attackBonus, damageBonus, weap.Damage)
 			}
-			
+
 			if err != nil {
 				log.Printf("Weapon attack error: %v", err)
 				return nil, err
@@ -137,7 +137,7 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 				if offWeap, offOk := c.EquippedSlots[SlotOffHand].(*Weapon); offOk {
 					// Same process for off-hand weapon
 					offHandProficient := c.hasWeaponProficiencyInternal(offWeap.GetKey())
-					
+
 					var offHandAbilityBonus int
 					switch offWeap.WeaponRange {
 					case "Ranged":
@@ -145,15 +145,15 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 					case "Melee":
 						offHandAbilityBonus = c.Attributes[AttributeStrength].Bonus
 					}
-					
+
 					offHandProficiencyBonus := 0
 					if offHandProficient {
 						offHandProficiencyBonus = 2 + ((c.Level - 1) / 4)
 					}
-					
+
 					offHandAttackBonus := offHandAbilityBonus + offHandProficiencyBonus
 					offHandDamageBonus := offHandAbilityBonus
-					
+
 					attak2, err := attack.RollAttack(offHandAttackBonus, offHandDamageBonus, offWeap.Damage)
 					if err != nil {
 						return nil, err
@@ -176,7 +176,7 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 		if weap, ok := c.EquippedSlots[SlotTwoHanded].(*Weapon); ok {
 			// Check proficiency while we have the mutex
 			isProficient := c.hasWeaponProficiencyInternal(weap.GetKey())
-			
+
 			// Calculate ability bonus based on weapon type
 			var abilityBonus int
 			switch weap.WeaponRange {
@@ -185,16 +185,16 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 			case "Melee":
 				abilityBonus = c.Attributes[AttributeStrength].Bonus
 			}
-			
+
 			// Calculate proficiency bonus if proficient
 			proficiencyBonus := 0
 			if isProficient {
 				proficiencyBonus = 2 + ((c.Level - 1) / 4)
 			}
-			
+
 			attackBonus := abilityBonus + proficiencyBonus
 			damageBonus := abilityBonus
-			
+
 			// Two-handed weapons often have special damage
 			var dmg *damage.Damage
 			if weap.TwoHandedDamage != nil {
@@ -202,7 +202,7 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 			} else {
 				dmg = weap.Damage
 			}
-			
+
 			a, err := attack.RollAttack(attackBonus, damageBonus, dmg)
 			if err != nil {
 				return nil, err

--- a/internal/entities/character_attack_equipment_test.go
+++ b/internal/entities/character_attack_equipment_test.go
@@ -98,14 +98,14 @@ func TestCharacterAttackFallbackBehavior(t *testing.T) {
 	}
 
 	results, err := char.Attack()
-	
+
 	// Current behavior: returns nil
 	// Better behavior: should return improvised weapon attack or unarmed strike
 	require.NoError(t, err)
-	
+
 	// This will fail with current code
 	// assert.NotEmpty(t, results, "Should fall back to improvised/unarmed attack")
-	
+
 	// Document current behavior
 	assert.Empty(t, results, "Currently returns no results for non-weapon equipment")
 }

--- a/internal/entities/encounter.go
+++ b/internal/entities/encounter.go
@@ -191,7 +191,7 @@ func (e *Encounter) CanPlayerAct(playerID string) bool {
 func (e *Encounter) CheckCombatEnd() (shouldEnd bool, playersWon bool) {
 	activeMonsters := 0
 	activePlayers := 0
-	
+
 	for _, combatant := range e.Combatants {
 		if combatant.IsActive {
 			if combatant.Type == CombatantTypeMonster {
@@ -201,14 +201,14 @@ func (e *Encounter) CheckCombatEnd() (shouldEnd bool, playersWon bool) {
 			}
 		}
 	}
-	
+
 	// Combat ends if either side has no active combatants
 	if activeMonsters == 0 && activePlayers > 0 {
 		return true, true // Players won
 	} else if activePlayers == 0 && activeMonsters > 0 {
 		return true, false // Players lost
 	}
-	
+
 	return false, false
 }
 
@@ -261,7 +261,7 @@ func (e *Encounter) AddCombatLogEntry(entry string) {
 	// Prefix with round number
 	logEntry := fmt.Sprintf("Round %d: %s", e.Round, entry)
 	e.CombatLog = append(e.CombatLog, logEntry)
-	
+
 	// Keep only last 20 entries to prevent unbounded growth
 	if len(e.CombatLog) > 20 {
 		e.CombatLog = e.CombatLog[len(e.CombatLog)-20:]

--- a/internal/entities/encounter_test.go
+++ b/internal/entities/encounter_test.go
@@ -10,7 +10,7 @@ import (
 func TestCheckCombatEnd(t *testing.T) {
 	t.Run("Players win when all monsters defeated", func(t *testing.T) {
 		encounter := entities.NewEncounter("enc-1", "session-1", "channel-1", "Test Combat", "dm-1")
-		
+
 		// Add player
 		player := &entities.Combatant{
 			ID:        "player-1",
@@ -21,7 +21,7 @@ func TestCheckCombatEnd(t *testing.T) {
 			IsActive:  true,
 		}
 		encounter.AddCombatant(player)
-		
+
 		// Add defeated monster
 		monster := &entities.Combatant{
 			ID:        "monster-1",
@@ -32,15 +32,15 @@ func TestCheckCombatEnd(t *testing.T) {
 			IsActive:  false,
 		}
 		encounter.AddCombatant(monster)
-		
+
 		shouldEnd, playersWon := encounter.CheckCombatEnd()
 		assert.True(t, shouldEnd)
 		assert.True(t, playersWon)
 	})
-	
+
 	t.Run("Players lose when all players defeated", func(t *testing.T) {
 		encounter := entities.NewEncounter("enc-2", "session-1", "channel-1", "Test Combat", "dm-1")
-		
+
 		// Add defeated player
 		player := &entities.Combatant{
 			ID:        "player-1",
@@ -51,7 +51,7 @@ func TestCheckCombatEnd(t *testing.T) {
 			IsActive:  false,
 		}
 		encounter.AddCombatant(player)
-		
+
 		// Add active monster
 		monster := &entities.Combatant{
 			ID:        "monster-1",
@@ -62,15 +62,15 @@ func TestCheckCombatEnd(t *testing.T) {
 			IsActive:  true,
 		}
 		encounter.AddCombatant(monster)
-		
+
 		shouldEnd, playersWon := encounter.CheckCombatEnd()
 		assert.True(t, shouldEnd)
 		assert.False(t, playersWon)
 	})
-	
+
 	t.Run("Combat continues when both sides have active combatants", func(t *testing.T) {
 		encounter := entities.NewEncounter("enc-3", "session-1", "channel-1", "Test Combat", "dm-1")
-		
+
 		// Add active player
 		player := &entities.Combatant{
 			ID:        "player-1",
@@ -81,7 +81,7 @@ func TestCheckCombatEnd(t *testing.T) {
 			IsActive:  true,
 		}
 		encounter.AddCombatant(player)
-		
+
 		// Add active monster
 		monster := &entities.Combatant{
 			ID:        "monster-1",
@@ -92,7 +92,7 @@ func TestCheckCombatEnd(t *testing.T) {
 			IsActive:  true,
 		}
 		encounter.AddCombatant(monster)
-		
+
 		shouldEnd, playersWon := encounter.CheckCombatEnd()
 		assert.False(t, shouldEnd)
 		assert.False(t, playersWon)
@@ -103,21 +103,21 @@ func TestCombatLog(t *testing.T) {
 	t.Run("Adds entries with round number", func(t *testing.T) {
 		encounter := entities.NewEncounter("enc-1", "session-1", "channel-1", "Test Combat", "dm-1")
 		encounter.Round = 2
-		
+
 		encounter.AddCombatLogEntry("Goblin hit Hero for 5 damage")
-		
+
 		assert.Len(t, encounter.CombatLog, 1)
 		assert.Equal(t, "Round 2: Goblin hit Hero for 5 damage", encounter.CombatLog[0])
 	})
-	
+
 	t.Run("Maintains maximum of 20 entries", func(t *testing.T) {
 		encounter := entities.NewEncounter("enc-2", "session-1", "channel-1", "Test Combat", "dm-1")
-		
+
 		// Add 25 entries
 		for i := 0; i < 25; i++ {
 			encounter.AddCombatLogEntry("Test action")
 		}
-		
+
 		assert.Len(t, encounter.CombatLog, 20)
 		// First 5 entries should have been removed
 		assert.Equal(t, "Round 0: Test action", encounter.CombatLog[0])

--- a/internal/entities/weapon_test.go
+++ b/internal/entities/weapon_test.go
@@ -34,7 +34,7 @@ func TestWeaponAttackCalculations(t *testing.T) {
 			Damage: &damage.Damage{
 				DiceCount:  1,
 				DiceSize:   8,
-				Bonus:     0,
+				Bonus:      0,
 				DamageType: damage.TypeSlashing,
 			},
 		}
@@ -42,7 +42,7 @@ func TestWeaponAttackCalculations(t *testing.T) {
 		result, err := weapon.Attack(char)
 		require.NoError(t, err)
 		require.NotNil(t, result)
-		
+
 		// Attack bonus should be STR modifier (3) + proficiency bonus (2) = 5
 		// Note: result.AttackRoll includes the d20 roll, so we can't test exact value
 		// But we can verify the logic by checking if proficiency is detected
@@ -59,14 +59,14 @@ func TestWeaponAttackCalculations(t *testing.T) {
 			Damage: &damage.Damage{
 				DiceCount:  1,
 				DiceSize:   6,
-				Bonus:     0,
+				Bonus:      0,
 				DamageType: damage.TypePiercing,
 			},
 		}
 
 		result, err := weapon.Attack(char)
 		require.NoError(t, err)
-		
+
 		// Should use DEX modifier for ranged weapons
 		assert.NotNil(t, result)
 		assert.True(t, char.HasWeaponProficiency("shortbow"))
@@ -82,14 +82,14 @@ func TestWeaponAttackCalculations(t *testing.T) {
 			Damage: &damage.Damage{
 				DiceCount:  1,
 				DiceSize:   12,
-				Bonus:     0,
+				Bonus:      0,
 				DamageType: damage.TypeSlashing,
 			},
 		}
 
 		result, err := weapon.Attack(char)
 		require.NoError(t, err)
-		
+
 		// Should not have proficiency bonus
 		assert.False(t, char.HasWeaponProficiency("greataxe"))
 		assert.NotNil(t, result)
@@ -97,8 +97,8 @@ func TestWeaponAttackCalculations(t *testing.T) {
 
 	t.Run("Proficiency bonus scales with level", func(t *testing.T) {
 		testCases := []struct {
-			level          int
-			expectedBonus  int
+			level         int
+			expectedBonus int
 		}{
 			{1, 2},  // Level 1-4: +2
 			{4, 2},  // Level 1-4: +2
@@ -112,10 +112,10 @@ func TestWeaponAttackCalculations(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Logf("Testing level %d", tc.level)
-			
+
 			// Calculate expected proficiency bonus using same formula as weapon code
 			expectedProfBonus := 2 + ((tc.level - 1) / 4)
-			assert.Equal(t, tc.expectedBonus, expectedProfBonus, 
+			assert.Equal(t, tc.expectedBonus, expectedProfBonus,
 				"Level %d should have proficiency bonus %d", tc.level, tc.expectedBonus)
 		}
 	})

--- a/internal/handlers/discord/dnd/character/no_coward_test.go
+++ b/internal/handlers/discord/dnd/character/no_coward_test.go
@@ -9,7 +9,7 @@ import (
 // TestNoCowardRules verifies that reroll options are not available
 func TestNoCowardRules(t *testing.T) {
 	// This is more of a documentation test to show our no-coward philosophy
-	
+
 	testCases := []struct {
 		name        string
 		totalScore  int

--- a/internal/handlers/discord/dnd/character/proficiency_choices.go
+++ b/internal/handlers/discord/dnd/character/proficiency_choices.go
@@ -96,7 +96,7 @@ func (h *ProficiencyChoicesHandler) Handle(req *ProficiencyChoicesRequest) error
 			{"WIS", entities.AttributeWisdom},
 			{"CHA", entities.AttributeCharisma},
 		}
-		
+
 		for _, ability := range abilities {
 			if score, ok := draftChar.Attributes[ability.attr]; ok && score != nil {
 				modifier := score.Bonus
@@ -106,7 +106,7 @@ func (h *ProficiencyChoicesHandler) Handle(req *ProficiencyChoicesRequest) error
 				scoreLines = append(scoreLines, fmt.Sprintf("**%s:** -", ability.name))
 			}
 		}
-		
+
 		if len(scoreLines) > 0 {
 			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 				Name:   "📊 Ability Scores",

--- a/internal/handlers/discord/dnd/character/roll_all.go
+++ b/internal/handlers/discord/dnd/character/roll_all.go
@@ -141,14 +141,14 @@ func (h *RollAllHandler) Handle(req *RollAllRequest) error {
 	for _, roll := range rolls {
 		totalScore += roll.Value
 	}
-	
+
 	flavorText := "The dice have spoken! Your fate is sealed."
 	if totalScore >= 78 { // Average of 13+ per stat
 		flavorText = "The gods smile upon you! An exceptional set of rolls."
 	} else if totalScore <= 60 { // Average of 10- per stat
 		flavorText = "The dice show no mercy... But legends are born from adversity!"
 	}
-	
+
 	embed.Footer = &discordgo.MessageEmbedFooter{
 		Text: flavorText,
 	}

--- a/internal/handlers/discord/dnd/character/roll_individual.go
+++ b/internal/handlers/discord/dnd/character/roll_individual.go
@@ -154,7 +154,7 @@ func (h *RollIndividualHandler) Handle(req *RollIndividualRequest) error {
 		} else if currentRoll.Value <= 10 {
 			rollFlavor = "\n*Below average, but workable.*"
 		}
-		
+
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 			Name:   "🎲 Dice Rolled",
 			Value:  fmt.Sprintf("**Rolled:** %s\n**Dropped:** %d (lowest)\n**Total:** %d%s", strings.Join(diceStr, ", "), sortedDice[0], currentRoll.Value, rollFlavor),
@@ -236,14 +236,14 @@ func (h *RollIndividualHandler) Handle(req *RollIndividualRequest) error {
 		for _, roll := range existingRolls {
 			totalScore += roll.Value
 		}
-		
+
 		flavorText := "The dice have spoken! Your fate is sealed."
 		if totalScore >= 78 { // Average of 13+ per stat
 			flavorText = "The gods smile upon you! An exceptional set of rolls."
 		} else if totalScore <= 60 { // Average of 10- per stat
 			flavorText = "The dice show no mercy... But legends are born from adversity!"
 		}
-		
+
 		embed.Title = "All Ability Scores Rolled!"
 		embed.Footer = &discordgo.MessageEmbedFooter{
 			Text: flavorText,

--- a/internal/handlers/discord/dnd/character/weapon.go
+++ b/internal/handlers/discord/dnd/character/weapon.go
@@ -218,7 +218,7 @@ func (h *WeaponHandler) HandleUnequip(s *discordgo.Session, i *discordgo.Interac
 
 	// Convert slot name to Slot type
 	slot := entities.Slot(slotName)
-	
+
 	// Check if anything is equipped in that slot
 	if char.EquippedSlots == nil || char.EquippedSlots[slot] == nil {
 		return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{

--- a/internal/handlers/discord/dnd/dungeon/dungeon.go
+++ b/internal/handlers/discord/dnd/dungeon/dungeon.go
@@ -116,7 +116,7 @@ func (h *StartDungeonHandler) Handle(req *StartDungeonRequest) error {
 		log.Printf("StartDungeon - Error listing characters for user %s: %v", req.Interaction.Member.User.ID, err)
 	} else {
 		log.Printf("StartDungeon - User %s has %d characters", req.Interaction.Member.User.ID, len(chars))
-		
+
 		// Find first active character
 		var activeCount int
 		for _, char := range chars {
@@ -124,14 +124,14 @@ func (h *StartDungeonHandler) Handle(req *StartDungeonRequest) error {
 				activeCount++
 				if characterName == "" { // Auto-select first active
 					// Select this character for the session
-					log.Printf("StartDungeon - Auto-selecting character %s (ID: %s) for user %s", 
+					log.Printf("StartDungeon - Auto-selecting character %s (ID: %s) for user %s",
 						char.Name, char.ID, req.Interaction.Member.User.ID)
 					err = h.services.SessionService.SelectCharacter(context.Background(), sess.ID, req.Interaction.Member.User.ID, char.ID)
 					if err != nil {
 						log.Printf("StartDungeon - WARNING: Failed to auto-select character: %v", err)
 					} else {
 						characterName = char.Name
-						
+
 						// Update the member's CharacterID directly since we just selected it
 						if member, exists := sess.Members[req.Interaction.Member.User.ID]; exists {
 							member.CharacterID = char.ID
@@ -141,7 +141,7 @@ func (h *StartDungeonHandler) Handle(req *StartDungeonRequest) error {
 				}
 			}
 		}
-		
+
 		if activeCount > 1 {
 			log.Printf("StartDungeon - User has %d active characters, auto-selected first one", activeCount)
 		} else if activeCount == 0 {

--- a/internal/handlers/discord/dnd/dungeon/enter_room.go
+++ b/internal/handlers/discord/dnd/dungeon/enter_room.go
@@ -27,7 +27,7 @@ func NewEnterRoomHandler(serviceProvider *services.Provider) *EnterRoomHandler {
 
 func (h *EnterRoomHandler) HandleButton(s *discordgo.Session, i *discordgo.InteractionCreate, sessionID, roomType string) error {
 	log.Printf("EnterRoom - User %s attempting to enter %s room in session %s", i.Member.User.ID, roomType, sessionID)
-	
+
 	// Get session
 	sess, err := h.services.SessionService.GetSession(context.Background(), sessionID)
 	if err != nil {
@@ -52,7 +52,7 @@ func (h *EnterRoomHandler) HandleButton(s *discordgo.Session, i *discordgo.Inter
 			},
 		})
 	}
-	
+
 	// Check if user has a character selected (except for DM/bot)
 	member, exists := sess.Members[i.Member.User.ID]
 	if exists && member.Role == entities.SessionRolePlayer && member.CharacterID == "" {
@@ -65,7 +65,7 @@ func (h *EnterRoomHandler) HandleButton(s *discordgo.Session, i *discordgo.Inter
 			},
 		})
 	}
-	
+
 	if exists {
 		log.Printf("EnterRoom - User %s has role=%s, characterID=%s", i.Member.User.ID, member.Role, member.CharacterID)
 	}
@@ -206,7 +206,7 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 			},
 		})
 	}
-	
+
 	// Process initial monster turns if they go first
 	var monsterActions []string
 	for enc.Status == entities.EncounterStatusActive {
@@ -214,10 +214,10 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 		if current == nil || current.Type != entities.CombatantTypeMonster {
 			break // Stop when we reach a player's turn
 		}
-		
+
 		// Process monster turn
 		log.Printf("Processing initial monster turn for %s", current.Name)
-		
+
 		// Find a target (first active player)
 		var target *entities.Combatant
 		for _, combatant := range enc.Combatants {
@@ -226,16 +226,16 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 				break
 			}
 		}
-		
+
 		if target != nil && len(current.Actions) > 0 {
 			// Use first available action
 			action := current.Actions[0]
-			
+
 			// Roll attack
 			attackResult, _ := dice.Roll(1, 20, 0)
 			attackRoll := attackResult.Total
 			totalAttack := attackRoll + action.AttackBonus
-			
+
 			// Check if hit
 			hit := totalAttack >= target.AC
 			if hit && len(action.Damage) > 0 {
@@ -248,26 +248,26 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 					rollResult, _ := dice.Roll(diceCount, dmg.DiceSize, dmg.Bonus)
 					totalDamage += rollResult.Total
 				}
-				
+
 				// Apply damage
 				err = h.services.EncounterService.ApplyDamage(context.Background(), enc.ID, target.ID, botID, totalDamage)
 				if err != nil {
 					log.Printf("Error applying initial monster damage: %v", err)
 				}
-				
+
 				monsterActions = append(monsterActions, fmt.Sprintf("%s attacks %s with %s for %d damage!", current.Name, target.Name, action.Name, totalDamage))
 			} else {
 				monsterActions = append(monsterActions, fmt.Sprintf("%s misses %s with %s!", current.Name, target.Name, action.Name))
 			}
 		}
-		
+
 		// Advance turn
 		err = h.services.EncounterService.NextTurn(context.Background(), enc.ID, botID)
 		if err != nil {
 			log.Printf("Error advancing initial monster turn: %v", err)
 			break
 		}
-		
+
 		// Re-get encounter for next iteration
 		enc, err = h.services.EncounterService.GetEncounter(context.Background(), enc.ID)
 		if err != nil {
@@ -296,7 +296,7 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 			Inline: false,
 		})
 	}
-	
+
 	// Show enemies
 	var enemyList strings.Builder
 	for _, combatant := range enc.Combatants {
@@ -322,7 +322,7 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 			turnOrder.WriteString(fmt.Sprintf("%s %s\n", prefix, combatant.Name))
 		}
 	}
-	
+
 	// Show whose turn it is
 	if current := enc.GetCurrentCombatant(); current != nil {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
@@ -331,7 +331,7 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 			Inline: false,
 		})
 	}
-	
+
 	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 		Name:   "📋 Initiative Order",
 		Value:  turnOrder.String(),
@@ -343,7 +343,7 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 	if current := enc.GetCurrentCombatant(); current != nil && current.Type == entities.CombatantTypePlayer {
 		isPlayerTurn = true
 	}
-	
+
 	// Combat buttons
 	components := []discordgo.MessageComponent{
 		discordgo.ActionsRow{

--- a/internal/handlers/discord/dnd/dungeon/enter_room_test.go
+++ b/internal/handlers/discord/dnd/dungeon/enter_room_test.go
@@ -11,7 +11,7 @@ func TestEnterRoomValidation(t *testing.T) {
 	t.Run("Player cannot enter room without joining party", func(t *testing.T) {
 		// Session without the player as member
 		session := &entities.Session{
-			ID:      "session-123",
+			ID: "session-123",
 			Members: map[string]*entities.SessionMember{
 				"dm-123": {
 					UserID: "dm-123",
@@ -20,13 +20,13 @@ func TestEnterRoomValidation(t *testing.T) {
 				// Player is NOT in members
 			},
 		}
-		
+
 		playerID := "player-123"
 		canEnter := session.IsUserInSession(playerID)
-		
+
 		assert.False(t, canEnter, "Player should not be able to enter without joining")
 	})
-	
+
 	t.Run("Player cannot enter combat room without character", func(t *testing.T) {
 		// Session with player but no character selected
 		session := &entities.Session{
@@ -39,13 +39,13 @@ func TestEnterRoomValidation(t *testing.T) {
 				},
 			},
 		}
-		
+
 		member := session.Members["player-456"]
 		hasCharacter := member.CharacterID != ""
-		
+
 		assert.False(t, hasCharacter, "Player should not be able to enter combat without character")
 	})
-	
+
 	t.Run("Player with character can enter room", func(t *testing.T) {
 		// Session with player and character selected
 		session := &entities.Session{
@@ -58,14 +58,14 @@ func TestEnterRoomValidation(t *testing.T) {
 				},
 			},
 		}
-		
+
 		playerID := "player-789"
 		member := session.Members[playerID]
-		
+
 		canEnter := session.IsUserInSession(playerID) && member.CharacterID != ""
 		assert.True(t, canEnter, "Player with character should be able to enter")
 	})
-	
+
 	t.Run("DM can enter room without character", func(t *testing.T) {
 		// DM doesn't need a character
 		session := &entities.Session{
@@ -78,14 +78,14 @@ func TestEnterRoomValidation(t *testing.T) {
 				},
 			},
 		}
-		
+
 		dmID := "dm-999"
 		member := session.Members[dmID]
-		
+
 		// DM can enter regardless of character
-		canEnter := session.IsUserInSession(dmID) && 
+		canEnter := session.IsUserInSession(dmID) &&
 			(member.Role == entities.SessionRoleDM || member.CharacterID != "")
-		
+
 		assert.True(t, canEnter, "DM should be able to enter without character")
 	})
 }
@@ -95,66 +95,66 @@ func TestDungeonWorkflowOrder(t *testing.T) {
 		// 1. Start dungeon
 		dungeonStarted := true
 		assert.True(t, dungeonStarted)
-		
+
 		// 2. Join party (selects character)
 		characterSelected := true
 		assert.True(t, characterSelected)
-		
+
 		// 3. Enter room (now allowed)
 		canEnterRoom := dungeonStarted && characterSelected
 		assert.True(t, canEnterRoom)
 	})
-	
+
 	t.Run("Incorrect workflow - skip join party", func(t *testing.T) {
 		// 1. Start dungeon
 		dungeonStarted := true
 		assert.True(t, dungeonStarted)
-		
+
 		// 2. Try to enter room without joining (no character selected)
 		characterSelected := false
 		canEnterRoom := dungeonStarted && characterSelected
-		
+
 		assert.False(t, canEnterRoom, "Should not be able to enter without joining party")
 	})
 }
 
 func TestCharacterRequirementsByRoomType(t *testing.T) {
 	testCases := []struct {
-		name             string
-		roomType         string
+		name              string
+		roomType          string
 		requiresCharacter bool
 	}{
 		{
-			name:             "Combat room requires character",
-			roomType:         "combat",
+			name:              "Combat room requires character",
+			roomType:          "combat",
 			requiresCharacter: true,
 		},
 		{
-			name:             "Puzzle room requires character",
-			roomType:         "puzzle",
+			name:              "Puzzle room requires character",
+			roomType:          "puzzle",
 			requiresCharacter: true,
 		},
 		{
-			name:             "Trap room requires character",
-			roomType:         "trap",
+			name:              "Trap room requires character",
+			roomType:          "trap",
 			requiresCharacter: true,
 		},
 		{
-			name:             "Treasure room requires character",
-			roomType:         "treasure",
+			name:              "Treasure room requires character",
+			roomType:          "treasure",
 			requiresCharacter: true,
 		},
 		{
-			name:             "Rest room requires character",
-			roomType:         "rest",
+			name:              "Rest room requires character",
+			roomType:          "rest",
 			requiresCharacter: true,
 		},
 	}
-	
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// All room types require a character for players
-			assert.True(t, tc.requiresCharacter, 
+			assert.True(t, tc.requiresCharacter,
 				"Room type %s should require character for players", tc.roomType)
 		})
 	}

--- a/internal/handlers/discord/dnd/dungeon/join.go
+++ b/internal/handlers/discord/dnd/dungeon/join.go
@@ -23,7 +23,7 @@ func NewJoinPartyHandler(serviceProvider *services.Provider) *JoinPartyHandler {
 
 func (h *JoinPartyHandler) HandleButton(s *discordgo.Session, i *discordgo.InteractionCreate, sessionID string) error {
 	log.Printf("JoinParty - User %s attempting to join session %s", i.Member.User.ID, sessionID)
-	
+
 	// Get user's active character
 	chars, err := h.services.CharacterService.ListByOwner(i.Member.User.ID)
 	if err != nil {
@@ -36,7 +36,7 @@ func (h *JoinPartyHandler) HandleButton(s *discordgo.Session, i *discordgo.Inter
 			},
 		})
 	}
-	
+
 	if len(chars) == 0 {
 		log.Printf("JoinParty - User %s has no characters", i.Member.User.ID)
 		return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -47,7 +47,7 @@ func (h *JoinPartyHandler) HandleButton(s *discordgo.Session, i *discordgo.Inter
 			},
 		})
 	}
-	
+
 	log.Printf("JoinParty - User %s has %d characters", i.Member.User.ID, len(chars))
 
 	// Find first active character
@@ -62,7 +62,7 @@ func (h *JoinPartyHandler) HandleButton(s *discordgo.Session, i *discordgo.Inter
 			}
 		}
 	}
-	
+
 	log.Printf("JoinParty - Found %d active characters", activeCount)
 
 	if playerChar == nil {
@@ -116,7 +116,7 @@ func (h *JoinPartyHandler) HandleButton(s *discordgo.Session, i *discordgo.Inter
 			},
 		})
 	}
-	
+
 	// If not in session, join it
 	if !sess.IsUserInSession(i.Member.User.ID) {
 		log.Printf("User %s not in session, joining...", i.Member.User.ID)
@@ -148,17 +148,17 @@ func (h *JoinPartyHandler) HandleButton(s *discordgo.Session, i *discordgo.Inter
 		})
 	}
 	log.Printf("Successfully selected character %s for user %s", playerChar.Name, i.Member.User.ID)
-	
+
 	// Verify the character was set
 	sess, getErr := h.services.SessionService.GetSession(context.Background(), sessionID)
 	if getErr == nil && sess != nil {
 		if member, exists := sess.Members[i.Member.User.ID]; exists {
-			log.Printf("JoinParty - Verified session member - UserID: %s, Role: %s, CharacterID: %s", 
+			log.Printf("JoinParty - Verified session member - UserID: %s, Role: %s, CharacterID: %s",
 				member.UserID, member.Role, member.CharacterID)
 		} else {
 			log.Printf("JoinParty - WARNING: User %s not found in session members after join", i.Member.User.ID)
 		}
-		
+
 		// Log all session members for debugging
 		log.Printf("JoinParty - Current session members:")
 		for uid, m := range sess.Members {

--- a/internal/handlers/discord/dnd/dungeon/join_test.go
+++ b/internal/handlers/discord/dnd/dungeon/join_test.go
@@ -12,7 +12,7 @@ func TestJoinPartyWorkflow(t *testing.T) {
 		// Simulates: User starts dungeon (auto-added to session) then clicks "Select Character"
 		userID := "player-123"
 		characterID := "char-123"
-		
+
 		session := &entities.Session{
 			ID: "session-123",
 			Members: map[string]*entities.SessionMember{
@@ -23,24 +23,24 @@ func TestJoinPartyWorkflow(t *testing.T) {
 				},
 			},
 		}
-		
+
 		// User is already in session
 		assert.True(t, session.IsUserInSession(userID))
-		
+
 		// But has no character
 		member := session.Members[userID]
 		assert.Empty(t, member.CharacterID)
-		
+
 		// After selecting character
 		member.CharacterID = characterID
 		assert.Equal(t, characterID, member.CharacterID)
 	})
-	
+
 	t.Run("New user not in session joins with character", func(t *testing.T) {
 		// Simulates: Another player joins an existing dungeon
 		existingUserID := "player-existing"
 		newUserID := "player-new"
-		
+
 		session := &entities.Session{
 			ID: "session-456",
 			Members: map[string]*entities.SessionMember{
@@ -51,61 +51,61 @@ func TestJoinPartyWorkflow(t *testing.T) {
 				},
 			},
 		}
-		
+
 		// New user is not in session
 		assert.False(t, session.IsUserInSession(newUserID))
-		
+
 		// After joining
 		session.Members[newUserID] = &entities.SessionMember{
 			UserID:      newUserID,
 			Role:        entities.SessionRolePlayer,
 			CharacterID: "char-new",
 		}
-		
+
 		assert.True(t, session.IsUserInSession(newUserID))
 		assert.NotEmpty(t, session.Members[newUserID].CharacterID)
 	})
-	
+
 	t.Run("Cannot enter room workflow states", func(t *testing.T) {
 		userID := "player-789"
-		
+
 		testCases := []struct {
-			name        string
-			inSession   bool
+			name         string
+			inSession    bool
 			hasCharacter bool
-			canEnter    bool
-			errorMsg    string
+			canEnter     bool
+			errorMsg     string
 		}{
 			{
-				name:        "Not in session",
-				inSession:   false,
+				name:         "Not in session",
+				inSession:    false,
 				hasCharacter: false,
-				canEnter:    false,
-				errorMsg:    "You need to join the party first!",
+				canEnter:     false,
+				errorMsg:     "You need to join the party first!",
 			},
 			{
-				name:        "In session but no character",
-				inSession:   true,
+				name:         "In session but no character",
+				inSession:    true,
 				hasCharacter: false,
-				canEnter:    false,
-				errorMsg:    "You need to select a character! Click 'Select Character' first.",
+				canEnter:     false,
+				errorMsg:     "You need to select a character! Click 'Select Character' first.",
 			},
 			{
-				name:        "In session with character",
-				inSession:   true,
+				name:         "In session with character",
+				inSession:    true,
 				hasCharacter: true,
-				canEnter:    true,
-				errorMsg:    "",
+				canEnter:     true,
+				errorMsg:     "",
 			},
 		}
-		
+
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				session := &entities.Session{
 					ID:      "session-test",
 					Members: map[string]*entities.SessionMember{},
 				}
-				
+
 				if tc.inSession {
 					session.Members[userID] = &entities.SessionMember{
 						UserID: userID,
@@ -115,13 +115,13 @@ func TestJoinPartyWorkflow(t *testing.T) {
 						session.Members[userID].CharacterID = "char-test"
 					}
 				}
-				
+
 				// Check if can enter
 				canEnter := session.IsUserInSession(userID)
 				if canEnter && session.Members[userID].CharacterID == "" {
 					canEnter = false
 				}
-				
+
 				assert.Equal(t, tc.canEnter, canEnter)
 			})
 		}
@@ -135,10 +135,10 @@ func TestCharacterSelectionEdgeCases(t *testing.T) {
 			{ID: "char-1", Name: "Aragorn", Status: entities.CharacterStatusActive},
 			{ID: "char-2", Name: "Gandalf", Status: entities.CharacterStatusActive},
 		}
-		
+
 		// Should not auto-select when multiple active
 		assert.Greater(t, len(characters), 1)
-		
+
 		var activeCount int
 		for _, char := range characters {
 			if char.Status == entities.CharacterStatusActive {
@@ -147,38 +147,38 @@ func TestCharacterSelectionEdgeCases(t *testing.T) {
 		}
 		assert.Greater(t, activeCount, 1, "Multiple active characters prevent auto-selection")
 	})
-	
+
 	t.Run("Single active character can auto-select", func(t *testing.T) {
 		characters := []*entities.Character{
 			{ID: "char-1", Name: "Legolas", Status: entities.CharacterStatusActive},
 			{ID: "char-2", Name: "Gimli", Status: entities.CharacterStatusArchived},
 			{ID: "char-3", Name: "Boromir", Status: entities.CharacterStatusDraft},
 		}
-		
+
 		var activeChars []*entities.Character
 		for _, char := range characters {
 			if char.Status == entities.CharacterStatusActive {
 				activeChars = append(activeChars, char)
 			}
 		}
-		
+
 		assert.Len(t, activeChars, 1, "Exactly one active character allows auto-selection")
 		assert.Equal(t, "Legolas", activeChars[0].Name)
 	})
-	
+
 	t.Run("No active characters prevents joining", func(t *testing.T) {
 		characters := []*entities.Character{
 			{ID: "char-1", Name: "Draft Hero", Status: entities.CharacterStatusDraft},
 			{ID: "char-2", Name: "Old Hero", Status: entities.CharacterStatusArchived},
 		}
-		
+
 		var activeChars []*entities.Character
 		for _, char := range characters {
 			if char.Status == entities.CharacterStatusActive {
 				activeChars = append(activeChars, char)
 			}
 		}
-		
+
 		assert.Empty(t, activeChars, "No active characters to select")
 	})
 }

--- a/internal/repositories/characters/redis.go
+++ b/internal/repositories/characters/redis.go
@@ -85,7 +85,7 @@ func equipmentToData(eq entities.Equipment) (EquipmentData, error) {
 func dataToEquipment(data EquipmentData) (entities.Equipment, error) {
 	// Normalize type to handle legacy data
 	normalizedType := strings.ToLower(data.Type)
-	
+
 	switch normalizedType {
 	case "weapon":
 		var weapon entities.Weapon
@@ -126,7 +126,7 @@ func dataToEquipment(data EquipmentData) (entities.Equipment, error) {
 				return &armor, nil
 			}
 		}
-		
+
 		// Default to basic equipment
 		var basic entities.BasicEquipment
 		if err := json.Unmarshal(data.Equipment, &basic); err != nil {

--- a/internal/repositories/encounters/in_memory_test.go
+++ b/internal/repositories/encounters/in_memory_test.go
@@ -41,7 +41,7 @@ func TestInMemoryRepository_GetActiveBySession(t *testing.T) {
 	t.Run("Returns setup encounter when exists", func(t *testing.T) {
 		// Create a new session
 		sessionID2 := "test-session-456"
-		
+
 		// Create a setup encounter
 		setupEnc := entities.NewEncounter("enc-2", sessionID2, "channel-2", "Setup Encounter", "user-2")
 		setupEnc.Status = entities.EncounterStatusSetup
@@ -59,7 +59,7 @@ func TestInMemoryRepository_GetActiveBySession(t *testing.T) {
 	t.Run("Returns nil when only completed encounters exist", func(t *testing.T) {
 		// Create a new session
 		sessionID3 := "test-session-789"
-		
+
 		// Create a completed encounter
 		completedEnc := entities.NewEncounter("enc-3", sessionID3, "channel-3", "Completed Encounter", "user-3")
 		completedEnc.Status = entities.EncounterStatusCompleted

--- a/internal/services/character/inventory_display_bug_test.go
+++ b/internal/services/character/inventory_display_bug_test.go
@@ -64,7 +64,7 @@ func TestInventoryDisplayBug(t *testing.T) {
 		// Create a barbarian like Standre
 		draft, err := svc.GetOrCreateDraftCharacter(ctx, "test-barbarian", "test-realm")
 		require.NoError(t, err)
-		
+
 		// Set race and class
 		raceKey := "half-orc"
 		classKey := "barbarian"
@@ -100,20 +100,20 @@ func TestInventoryDisplayBug(t *testing.T) {
 		totalItems := 0
 		weaponTypeCount := 0
 		basicEquipmentCount := 0
-		
+
 		for eqType, items := range finalChar.Inventory {
 			log.Printf("Type '%s': %d items", eqType, len(items))
 			totalItems += len(items)
-			
+
 			if eqType == entities.EquipmentTypeWeapon {
 				weaponTypeCount = len(items)
 			}
 			if eqType == "BasicEquipment" {
 				basicEquipmentCount = len(items)
 			}
-			
+
 			for _, item := range items {
-				log.Printf("  - %s (key: %s, type from GetEquipmentType(): %s)", 
+				log.Printf("  - %s (key: %s, type from GetEquipmentType(): %s)",
 					item.GetName(), item.GetKey(), item.GetEquipmentType())
 			}
 		}
@@ -125,13 +125,13 @@ func TestInventoryDisplayBug(t *testing.T) {
 		// The bug: inventory command only shows EquipmentTypeWeapon
 		// but weapons were being stored with type "Weapon" instead of "weapon"
 		assert.Equal(t, 3, totalItems, "Should have 3 total items")
-		
+
 		// This is what the inventory handler checks
 		assert.Greater(t, weaponTypeCount, 0, "Should have weapons with EquipmentTypeWeapon")
-		
+
 		// After fix: weapons should use the constant
 		for _, item := range finalChar.Inventory[entities.EquipmentTypeWeapon] {
-			assert.Equal(t, entities.EquipmentTypeWeapon, item.GetEquipmentType(), 
+			assert.Equal(t, entities.EquipmentTypeWeapon, item.GetEquipmentType(),
 				"Weapon should return EquipmentTypeWeapon constant")
 		}
 	})
@@ -139,15 +139,15 @@ func TestInventoryDisplayBug(t *testing.T) {
 	t.Run("check what types D&D API returns", func(t *testing.T) {
 		// Let's see what the API actually returns for these items
 		items := []string{"greataxe", "handaxe", "explorers-pack"}
-		
+
 		for _, key := range items {
 			equipment, err := dndClient.GetEquipment(key)
 			if err != nil {
 				log.Printf("Error getting %s: %v", key, err)
 				continue
 			}
-			
-			log.Printf("Equipment '%s': Type = %T, GetEquipmentType() = %s", 
+
+			log.Printf("Equipment '%s': Type = %T, GetEquipmentType() = %s",
 				key, equipment, equipment.GetEquipmentType())
 		}
 	})

--- a/internal/services/character/service.go
+++ b/internal/services/character/service.go
@@ -1050,7 +1050,7 @@ func (s *service) StartFreshCharacterCreation(ctx context.Context, userID, realm
 			return nil, dnderr.Wrap(err, "failed to clear ability rolls").
 				WithMeta("character_id", draft.ID)
 		}
-		
+
 		// Refetch the updated draft
 		draft, err = s.GetCharacter(ctx, draft.ID)
 		if err != nil {

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -54,7 +54,7 @@ type Service interface {
 
 	// EndEncounter ends the encounter
 	EndEncounter(ctx context.Context, encounterID, userID string) error
-	
+
 	// LogCombatAction logs a combat action (like a miss) without damage
 	LogCombatAction(ctx context.Context, encounterID, action string) error
 }
@@ -289,7 +289,7 @@ func (s *service) AddPlayer(ctx context.Context, encounterID, playerID, characte
 	if err != nil {
 		return nil, dnderr.Wrap(err, "failed to get character")
 	}
-	
+
 	// Log character details
 	log.Printf("AddPlayer - Retrieved character: ID=%s, Name=%s, OwnerID=%s", character.ID, character.Name, character.OwnerID)
 
@@ -515,7 +515,7 @@ func (s *service) ApplyDamage(ctx context.Context, encounterID, combatantID, use
 		return dnderr.Wrap(err, "failed to get encounter")
 	}
 
-	// Check permissions 
+	// Check permissions
 	// For dungeon encounters, allow damage application regardless of turn
 	// since the bot orchestrates combat on behalf of players
 	if session, err := s.sessionService.GetSession(ctx, encounter.SessionID); err == nil {
@@ -538,7 +538,7 @@ func (s *service) ApplyDamage(ctx context.Context, encounterID, combatantID, use
 
 	// Apply damage
 	combatant.ApplyDamage(damage)
-	
+
 	// Add to combat log if damage was dealt
 	if damage > 0 {
 		// Find attacker name (could be current turn or explicit)
@@ -547,7 +547,7 @@ func (s *service) ApplyDamage(ctx context.Context, encounterID, combatantID, use
 			attackerName = current.Name
 		}
 		encounter.AddCombatLogEntry(fmt.Sprintf("%s hit %s for %d damage", attackerName, combatant.Name, damage))
-		
+
 		if combatant.CurrentHP == 0 {
 			encounter.AddCombatLogEntry(fmt.Sprintf("%s was defeated!", combatant.Name))
 		}
@@ -633,14 +633,14 @@ func (s *service) LogCombatAction(ctx context.Context, encounterID, action strin
 	if err != nil {
 		return dnderr.Wrap(err, "failed to get encounter")
 	}
-	
+
 	// Add to combat log
 	encounter.AddCombatLogEntry(action)
-	
+
 	// Save changes
 	if err := s.repository.Update(ctx, encounter); err != nil {
 		return dnderr.Wrap(err, "failed to update encounter")
 	}
-	
+
 	return nil
 }

--- a/internal/services/encounter/service_test.go
+++ b/internal/services/encounter/service_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
-	"github.com/KirkDiggler/dnd-bot-discord/internal/services/encounter"
 	mockcharacter "github.com/KirkDiggler/dnd-bot-discord/internal/services/character/mock"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/services/encounter"
 	mocksession "github.com/KirkDiggler/dnd-bot-discord/internal/services/session/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +17,7 @@ import (
 
 // MockUUIDGenerator is a simple UUID generator for testing
 type MockUUIDGenerator struct {
-	prefix string
+	prefix  string
 	counter int
 }
 
@@ -66,10 +66,10 @@ func (m *MockRepository) Delete(_ context.Context, id string) error {
 
 func (m *MockRepository) GetActiveBySession(_ context.Context, sessionID string) (*entities.Encounter, error) {
 	for _, encounter := range m.encounters {
-		if encounter.SessionID == sessionID && 
+		if encounter.SessionID == sessionID &&
 			(encounter.Status == entities.EncounterStatusActive ||
-			 encounter.Status == entities.EncounterStatusSetup ||
-			 encounter.Status == entities.EncounterStatusRolling) {
+				encounter.Status == entities.EncounterStatusSetup ||
+				encounter.Status == entities.EncounterStatusRolling) {
 			return encounter, nil
 		}
 	}
@@ -102,7 +102,7 @@ func TestCreateEncounter_DungeonSession(t *testing.T) {
 	mockSessionService := mocksession.NewMockService(ctrl)
 	mockCharService := mockcharacter.NewMockService(ctrl)
 	mockRepo := NewMockRepository()
-	
+
 	svc := encounter.NewService(&encounter.ServiceConfig{
 		Repository:       mockRepo,
 		SessionService:   mockSessionService,
@@ -118,8 +118,8 @@ func TestCreateEncounter_DungeonSession(t *testing.T) {
 
 		// Create a session with sessionType=dungeon in metadata
 		dungeonSession := &entities.Session{
-			ID:   sessionID,
-			Name: "Test Dungeon",
+			ID:      sessionID,
+			Name:    "Test Dungeon",
 			Members: map[string]*entities.SessionMember{
 				// Bot is not a member or DM
 			},
@@ -236,7 +236,7 @@ func TestAddPlayer(t *testing.T) {
 	mockSessionService := mocksession.NewMockService(ctrl)
 	mockCharService := mockcharacter.NewMockService(ctrl)
 	mockRepo := NewMockRepository()
-	
+
 	svc := encounter.NewService(&encounter.ServiceConfig{
 		Repository:       mockRepo,
 		SessionService:   mockSessionService,
@@ -254,7 +254,7 @@ func TestAddPlayer(t *testing.T) {
 	t.Run("Successfully adds player with correct character data", func(t *testing.T) {
 		playerID := "player-123"
 		characterID := "char-123"
-		
+
 		// Create test character
 		testChar := &entities.Character{
 			ID:               characterID,
@@ -267,19 +267,19 @@ func TestAddPlayer(t *testing.T) {
 				entities.AttributeDexterity: {Score: 18, Bonus: 4},
 			},
 		}
-		
+
 		// Mock character service to return test character
 		mockCharService.EXPECT().
 			GetByID(characterID).
 			Return(testChar, nil)
-		
+
 		// Add player
 		combatant, err := svc.AddPlayer(context.Background(), encounterID, playerID, characterID)
-		
+
 		// Verify success
 		require.NoError(t, err)
 		require.NotNil(t, combatant)
-		
+
 		// Verify combatant has correct data from character
 		assert.Equal(t, "Legolas", combatant.Name)
 		assert.Equal(t, entities.CombatantTypePlayer, combatant.Type)
@@ -290,7 +290,7 @@ func TestAddPlayer(t *testing.T) {
 		assert.Equal(t, 16, combatant.AC)
 		assert.Equal(t, 4, combatant.InitiativeBonus) // From DEX bonus
 		assert.True(t, combatant.IsActive)
-		
+
 		// Verify combatant was added to encounter
 		updatedEnc, _ := mockRepo.Get(context.Background(), encounterID)
 		assert.Len(t, updatedEnc.Combatants, 1)
@@ -300,7 +300,7 @@ func TestAddPlayer(t *testing.T) {
 	t.Run("Player name different from monster names", func(t *testing.T) {
 		// Reset encounter
 		testEncounter.Combatants = make(map[string]*entities.Combatant)
-		
+
 		// Add an Orc monster first
 		orcCombatant := &entities.Combatant{
 			ID:        "orc-1",
@@ -313,11 +313,11 @@ func TestAddPlayer(t *testing.T) {
 		}
 		testEncounter.AddCombatant(orcCombatant)
 		mockRepo.Update(context.Background(), testEncounter)
-		
+
 		// Now add a player
 		playerID := "player-456"
 		characterID := "char-456"
-		
+
 		testChar := &entities.Character{
 			ID:               characterID,
 			Name:             "Aragorn", // Not "Orc"
@@ -329,19 +329,19 @@ func TestAddPlayer(t *testing.T) {
 				entities.AttributeDexterity: {Score: 14, Bonus: 2},
 			},
 		}
-		
+
 		mockCharService.EXPECT().
 			GetByID(characterID).
 			Return(testChar, nil)
-		
+
 		// Add player
 		_, err := svc.AddPlayer(context.Background(), encounterID, playerID, characterID)
 		require.NoError(t, err)
-		
+
 		// Verify both combatants exist with correct names
 		updatedEnc, _ := mockRepo.Get(context.Background(), encounterID)
 		assert.Len(t, updatedEnc.Combatants, 2)
-		
+
 		// Find each combatant and verify
 		var foundOrc, foundPlayer bool
 		for _, c := range updatedEnc.Combatants {
@@ -361,7 +361,7 @@ func TestAddPlayer(t *testing.T) {
 	t.Run("Handles player with same name as monster", func(t *testing.T) {
 		// Reset encounter
 		testEncounter.Combatants = make(map[string]*entities.Combatant)
-		
+
 		// Add a Goblin monster
 		goblinMonster := &entities.Combatant{
 			ID:        "goblin-1",
@@ -374,11 +374,11 @@ func TestAddPlayer(t *testing.T) {
 		}
 		testEncounter.AddCombatant(goblinMonster)
 		mockRepo.Update(context.Background(), testEncounter)
-		
+
 		// Add a player named "Goblin" (edge case)
 		playerID := "player-789"
 		characterID := "char-789"
-		
+
 		testChar := &entities.Character{
 			ID:               characterID,
 			Name:             "Goblin", // Same name as monster!
@@ -390,19 +390,19 @@ func TestAddPlayer(t *testing.T) {
 				entities.AttributeDexterity: {Score: 16, Bonus: 3},
 			},
 		}
-		
+
 		mockCharService.EXPECT().
 			GetByID(characterID).
 			Return(testChar, nil)
-		
+
 		// Add player
 		_, err := svc.AddPlayer(context.Background(), encounterID, playerID, characterID)
 		require.NoError(t, err)
-		
+
 		// Verify both exist and can be distinguished by Type
 		updatedEnc, _ := mockRepo.Get(context.Background(), encounterID)
 		assert.Len(t, updatedEnc.Combatants, 2)
-		
+
 		// Count each type
 		var monsterGoblins, playerGoblins int
 		for _, c := range updatedEnc.Combatants {
@@ -424,20 +424,20 @@ func TestAddPlayer(t *testing.T) {
 	t.Run("Fails when character doesn't belong to player", func(t *testing.T) {
 		playerID := "player-999"
 		characterID := "char-999"
-		
+
 		testChar := &entities.Character{
 			ID:      characterID,
 			Name:    "Gimli",
 			OwnerID: "different-player", // Not the requesting player!
 		}
-		
+
 		mockCharService.EXPECT().
 			GetByID(characterID).
 			Return(testChar, nil)
-		
+
 		// Try to add player with someone else's character
 		combatant, err := svc.AddPlayer(context.Background(), encounterID, playerID, characterID)
-		
+
 		// Should fail with permission error
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "character does not belong to player")
@@ -455,7 +455,7 @@ func TestAddPlayer(t *testing.T) {
 		}
 		testEncounter.AddCombatant(existingCombatant)
 		mockRepo.Update(context.Background(), testEncounter)
-		
+
 		// Try to add same player again
 		characterID := "char-new"
 		testChar := &entities.Character{
@@ -463,13 +463,13 @@ func TestAddPlayer(t *testing.T) {
 			Name:    "New Character",
 			OwnerID: "player-123", // Same player!
 		}
-		
+
 		mockCharService.EXPECT().
 			GetByID(characterID).
 			Return(testChar, nil)
-		
+
 		combatant, err := svc.AddPlayer(context.Background(), encounterID, "player-123", characterID)
-		
+
 		// Should fail
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "player is already in the encounter")
@@ -480,7 +480,7 @@ func TestAddPlayer(t *testing.T) {
 func TestEncounterCombatantFiltering(t *testing.T) {
 	// Test that we can properly filter combatants by type
 	encounter := entities.NewEncounter("enc-1", "session-1", "channel-1", "Mixed Combat", "dm-1")
-	
+
 	// Add various combatants
 	player1 := &entities.Combatant{
 		ID:       "p1",
@@ -489,7 +489,7 @@ func TestEncounterCombatantFiltering(t *testing.T) {
 		PlayerID: "player-1",
 		IsActive: true,
 	}
-	
+
 	player2 := &entities.Combatant{
 		ID:       "p2",
 		Name:     "Orc", // Player named Orc!
@@ -497,26 +497,26 @@ func TestEncounterCombatantFiltering(t *testing.T) {
 		PlayerID: "player-2",
 		IsActive: true,
 	}
-	
+
 	monster1 := &entities.Combatant{
 		ID:       "m1",
 		Name:     "Orc",
 		Type:     entities.CombatantTypeMonster,
 		IsActive: true,
 	}
-	
+
 	monster2 := &entities.Combatant{
 		ID:       "m2",
 		Name:     "Goblin",
 		Type:     entities.CombatantTypeMonster,
 		IsActive: true,
 	}
-	
+
 	encounter.AddCombatant(player1)
 	encounter.AddCombatant(player2)
 	encounter.AddCombatant(monster1)
 	encounter.AddCombatant(monster2)
-	
+
 	t.Run("Can filter for monsters only", func(t *testing.T) {
 		var monsters []*entities.Combatant
 		for _, c := range encounter.Combatants {
@@ -524,7 +524,7 @@ func TestEncounterCombatantFiltering(t *testing.T) {
 				monsters = append(monsters, c)
 			}
 		}
-		
+
 		assert.Len(t, monsters, 2)
 		// Both should be monsters
 		for _, m := range monsters {
@@ -532,7 +532,7 @@ func TestEncounterCombatantFiltering(t *testing.T) {
 			assert.Empty(t, m.PlayerID)
 		}
 	})
-	
+
 	t.Run("Can filter for players only", func(t *testing.T) {
 		var players []*entities.Combatant
 		for _, c := range encounter.Combatants {
@@ -540,7 +540,7 @@ func TestEncounterCombatantFiltering(t *testing.T) {
 				players = append(players, c)
 			}
 		}
-		
+
 		assert.Len(t, players, 2)
 		// Both should be players
 		for _, p := range players {
@@ -548,7 +548,7 @@ func TestEncounterCombatantFiltering(t *testing.T) {
 			assert.NotEmpty(t, p.PlayerID)
 		}
 	})
-	
+
 	t.Run("Can distinguish same-named player and monster", func(t *testing.T) {
 		var orcs []*entities.Combatant
 		for _, c := range encounter.Combatants {
@@ -556,9 +556,9 @@ func TestEncounterCombatantFiltering(t *testing.T) {
 				orcs = append(orcs, c)
 			}
 		}
-		
+
 		assert.Len(t, orcs, 2, "Should find 2 combatants named Orc")
-		
+
 		// One should be player, one should be monster
 		var foundPlayer, foundMonster bool
 		for _, orc := range orcs {


### PR DESCRIPTION
## Description
Fix gofmt formatting issues that were causing CI checks to fail.

## Changes
- Ran `gofmt -w .` to format all Go files according to standard formatting
- No functional changes, only formatting

This will make the Quick Checks CI job pass again.