### PR TITLE
Add detailed attack roll information to combat

### DIFF
--- a/internal/handlers/discord/handler.go
+++ b/internal/handlers/discord/handler.go
@@ -3220,17 +3220,17 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 					if result.AttackResult != nil {
 						// Show dice roll details: 1d20 + bonus = total
 						rollsStr := fmt.Sprintf("%v", result.AttackResult.Rolls)
-						attackDetails = fmt.Sprintf("Roll: %s + %d = **%d**\nvs AC %d\n%s", 
-							rollsStr, 
-							result.AttackRoll - result.AttackResult.Total, // This is the bonus
+						attackDetails = fmt.Sprintf("Roll: %s + %d = **%d**\nvs AC %d\n%s",
+							rollsStr,
+							result.AttackRoll-result.AttackResult.Total, // This is the bonus
 							result.AttackRoll,
-							target.AC, 
+							target.AC,
 							hitText)
 					} else {
 						// Fallback if no detailed roll available
 						attackDetails = fmt.Sprintf("**Total:** %d vs AC %d\n%s", result.AttackRoll, target.AC, hitText)
 					}
-					
+
 					embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 						Name:   fmt.Sprintf("🎲 %s Roll", attackLabel),
 						Value:  attackDetails,
@@ -3245,14 +3245,14 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 							rollsStr := fmt.Sprintf("%v", result.DamageResult.Rolls)
 							damageBonus := result.DamageRoll - result.DamageResult.Total
 							if damageBonus != 0 {
-								damageDetails = fmt.Sprintf("Roll: %s + %d = **%d** %s", 
-									rollsStr, 
+								damageDetails = fmt.Sprintf("Roll: %s + %d = **%d** %s",
+									rollsStr,
 									damageBonus,
 									result.DamageRoll,
 									result.AttackType)
 							} else {
-								damageDetails = fmt.Sprintf("Roll: %s = **%d** %s", 
-									rollsStr, 
+								damageDetails = fmt.Sprintf("Roll: %s = **%d** %s",
+									rollsStr,
 									result.DamageRoll,
 									result.AttackType)
 							}
@@ -3260,7 +3260,7 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 							// Fallback if no detailed roll available
 							damageDetails = fmt.Sprintf("**Total:** %d %s damage", result.DamageRoll, result.AttackType)
 						}
-						
+
 						embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 							Name:   "💥 Damage",
 							Value:  damageDetails,
@@ -3276,13 +3276,13 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 					if len(attackResults) > 1 {
 						attackNum = fmt.Sprintf(" #%d", i+1)
 					}
-					
+
 					// Build the log entry with dice details
 					var logEntry string
 					if result.AttackResult != nil {
 						rollsStr := fmt.Sprintf("%v", result.AttackResult.Rolls)
 						bonus := result.AttackRoll - result.AttackResult.Total
-						
+
 						if result.AttackRoll >= target.AC {
 							// Hit - include damage details
 							if result.DamageResult != nil {
@@ -3314,11 +3314,11 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 							logEntry = fmt.Sprintf("⚔️ **%s** misses **%s**", current.Name, target.Name)
 						}
 					}
-					
+
 					// Log to combat history
 					_ = h.ServiceProvider.EncounterService.LogCombatAction(context.Background(), encounterID, logEntry)
 				}
-				
+
 				// Apply damage if any hit
 				if totalDamageDealt > 0 {
 					log.Printf("Attack result - %s dealt %d damage to %s", current.Name, totalDamageDealt, target.Name)

--- a/internal/repositories/characters/redis_equipment_migration.go
+++ b/internal/repositories/characters/redis_equipment_migration.go
@@ -1,0 +1,60 @@
+package characters
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+)
+
+// dataToEquipmentWithMigration converts EquipmentData back to Equipment interface
+// with support for legacy data formats
+func dataToEquipmentWithMigration(data EquipmentData) (entities.Equipment, error) {
+	// Normalize the type to lowercase for legacy compatibility
+	normalizedType := strings.ToLower(data.Type)
+
+	// Handle empty or unknown types
+	if normalizedType == "" || normalizedType == "unknown" {
+		// Try to detect type from the JSON structure
+		var rawData map[string]interface{}
+		if err := json.Unmarshal(data.Equipment, &rawData); err == nil {
+			// Check for weapon-specific fields
+			if _, hasWeaponCategory := rawData["weapon_category"]; hasWeaponCategory {
+				normalizedType = "weapon"
+			} else if _, hasArmorCategory := rawData["armor_category"]; hasArmorCategory {
+				normalizedType = "armor"
+			} else {
+				normalizedType = "basic"
+			}
+		}
+	}
+
+	switch normalizedType {
+	case "weapon":
+		var weapon entities.Weapon
+		if err := json.Unmarshal(data.Equipment, &weapon); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal weapon: %w", err)
+		}
+		return &weapon, nil
+	case "armor":
+		var armor entities.Armor
+		if err := json.Unmarshal(data.Equipment, &armor); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal armor: %w", err)
+		}
+		return &armor, nil
+	case "basic", "basicequipment":
+		var basic entities.BasicEquipment
+		if err := json.Unmarshal(data.Equipment, &basic); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal basic equipment: %w", err)
+		}
+		return &basic, nil
+	default:
+		// Last resort: try basic equipment
+		var basic entities.BasicEquipment
+		if err := json.Unmarshal(data.Equipment, &basic); err != nil {
+			return nil, fmt.Errorf("unknown equipment type '%s' and failed to parse as basic: %w", data.Type, err)
+		}
+		return &basic, nil
+	}
+}

--- a/internal/services/character/mock/mock_service.go
+++ b/internal/services/character/mock/mock_service.go
@@ -370,6 +370,20 @@ func (mr *MockServiceMockRecorder) UpdateDraftCharacter(ctx, characterID, update
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDraftCharacter", reflect.TypeOf((*MockService)(nil).UpdateDraftCharacter), ctx, characterID, updates)
 }
 
+// UpdateEquipment mocks base method.
+func (m *MockService) UpdateEquipment(arg0 *entities.Character) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateEquipment", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateEquipment indicates an expected call of UpdateEquipment.
+func (mr *MockServiceMockRecorder) UpdateEquipment(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEquipment", reflect.TypeOf((*MockService)(nil).UpdateEquipment), arg0)
+}
+
 // UpdateStatus mocks base method.
 func (m *MockService) UpdateStatus(characterID string, status entities.CharacterStatus) error {
 	m.ctrl.T.Helper()

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -388,6 +388,9 @@ func (s *service) RollInitiative(ctx context.Context, encounterID, userID string
 		return dnderr.InvalidArgument("encounter is not in setup phase")
 	}
 
+	// Clear combat log for new initiative rolls
+	encounter.CombatLog = []string{"🎲 **Rolling Initiative**"}
+	
 	// Roll initiative for each combatant
 	initiatives := make(map[string]int)
 	for id, combatant := range encounter.Combatants {
@@ -397,6 +400,14 @@ func (s *service) RollInitiative(ctx context.Context, encounterID, userID string
 		}
 		combatant.Initiative = rollResult.Total + combatant.InitiativeBonus
 		initiatives[id] = combatant.Initiative
+		
+		// Log the initiative roll
+		logEntry := fmt.Sprintf("**%s** rolls initiative: %v + %d = **%d**", 
+			combatant.Name, 
+			rollResult.Rolls[0], // The d20 roll
+			combatant.InitiativeBonus, 
+			combatant.Initiative)
+		encounter.CombatLog = append(encounter.CombatLog, logEntry)
 	}
 
 	// Sort combatants by initiative (descending)

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -390,7 +390,7 @@ func (s *service) RollInitiative(ctx context.Context, encounterID, userID string
 
 	// Clear combat log for new initiative rolls
 	encounter.CombatLog = []string{"🎲 **Rolling Initiative**"}
-	
+
 	// Roll initiative for each combatant
 	initiatives := make(map[string]int)
 	for id, combatant := range encounter.Combatants {
@@ -400,12 +400,12 @@ func (s *service) RollInitiative(ctx context.Context, encounterID, userID string
 		}
 		combatant.Initiative = rollResult.Total + combatant.InitiativeBonus
 		initiatives[id] = combatant.Initiative
-		
+
 		// Log the initiative roll
-		logEntry := fmt.Sprintf("**%s** rolls initiative: %v + %d = **%d**", 
-			combatant.Name, 
+		logEntry := fmt.Sprintf("**%s** rolls initiative: %v + %d = **%d**",
+			combatant.Name,
 			rollResult.Rolls[0], // The d20 roll
-			combatant.InitiativeBonus, 
+			combatant.InitiativeBonus,
 			combatant.Initiative)
 		encounter.CombatLog = append(encounter.CombatLog, logEntry)
 	}


### PR DESCRIPTION
## Description
This PR addresses issue #35 by adding detailed dice roll information to combat attacks and logging all combat actions with full details.

## Changes

### Attack Display Enhancements
- Attack rolls now show individual dice: `Roll: [15] + 5 = **20**` instead of just `Total: 20`
- Damage rolls show dice details: `Roll: [8] + 3 = **11** slashing`
- Critical hits and misses are clearly marked

### Combat History
- Initiative rolls are logged with details: `**Grunk** rolls initiative: 12 + 2 = **14**`
- All attacks are logged with full information:
  - `⚔️ **Grunk** attacks **Goblin** with Greataxe: Attack [15]+5=**20** vs AC 15 (HIT!) | Damage [8]+3=**11**`
  - `⚔️ **Goblin** attacks **Grunk** with Scimitar: [8]+3=**11** vs AC 16 (MISS!)`
- History button shows last 10 combat actions including initiative

## Testing
- Added detailed attack information to the embed fields
- Combat log captures all dice rolls and bonuses
- History display shows comprehensive combat record

## Screenshots
Players can now see:
- Exactly what dice were rolled
- What bonuses were applied
- Complete combat history with all details

Closes: #35