### PR TITLE
Fix equipment loading as BasicEquipment from Redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,9 @@ dev-test: redis-start test-all redis-stop
 
 # CI/CD simulation
 ci: lint test-all
+
+# Format targets
+format fmt:
+	@echo "Formatting Go code..."
+	@gofmt -w .
+	@go mod tidy

--- a/internal/repositories/characters/equipment_migration_test.go
+++ b/internal/repositories/characters/equipment_migration_test.go
@@ -113,15 +113,15 @@ func TestDataToEquipmentWithMigration(t *testing.T) {
 func TestEquipmentNilHandling(t *testing.T) {
 	// This test verifies that nil equipment is properly handled
 	// in the toCharacterData function
-	
+
 	char := &entities.Character{
 		ID:      "test-char",
 		OwnerID: "test-user",
 		RealmID: "test-realm",
 		Name:    "Test Character",
 		EquippedSlots: map[entities.Slot]entities.Equipment{
-			entities.SlotMainHand:  nil, // Nil equipment
-			entities.SlotOffHand:   nil,
+			entities.SlotMainHand: nil, // Nil equipment
+			entities.SlotOffHand:  nil,
 			entities.SlotTwoHanded: &entities.Weapon{
 				Base: entities.BasicEquipment{
 					Key:  "longsword",

--- a/internal/repositories/characters/equipment_migration_test.go
+++ b/internal/repositories/characters/equipment_migration_test.go
@@ -1,0 +1,145 @@
+package characters
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities/damage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataToEquipmentWithMigration(t *testing.T) {
+	// Create test weapon data
+	weaponJSON, err := json.Marshal(&entities.Weapon{
+		Base: entities.BasicEquipment{
+			Key:    "greataxe",
+			Name:   "Greataxe",
+			Weight: 7,
+		},
+		WeaponCategory: "martial",
+		WeaponRange:    "melee",
+		Damage: &damage.Damage{
+			DiceCount:  1,
+			DiceSize:   12,
+			DamageType: damage.TypeSlashing,
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		data         EquipmentData
+		expectedType string
+		validate     func(t *testing.T, eq entities.Equipment)
+	}{
+		{
+			name: "weapon with correct type",
+			data: EquipmentData{
+				Type:      "weapon",
+				Equipment: weaponJSON,
+			},
+			expectedType: "*entities.Weapon",
+			validate: func(t *testing.T, eq entities.Equipment) {
+				weapon, ok := eq.(*entities.Weapon)
+				require.True(t, ok)
+				assert.Equal(t, "greataxe", weapon.GetKey())
+				assert.Equal(t, "Greataxe", weapon.GetName())
+				assert.Equal(t, "martial", weapon.WeaponCategory)
+			},
+		},
+		{
+			name: "weapon with empty type (legacy)",
+			data: EquipmentData{
+				Type:      "",
+				Equipment: weaponJSON,
+			},
+			expectedType: "*entities.Weapon",
+			validate: func(t *testing.T, eq entities.Equipment) {
+				weapon, ok := eq.(*entities.Weapon)
+				require.True(t, ok)
+				assert.Equal(t, "greataxe", weapon.GetKey())
+				assert.Equal(t, "martial", weapon.WeaponCategory)
+			},
+		},
+		{
+			name: "weapon with unknown type",
+			data: EquipmentData{
+				Type:      "unknown",
+				Equipment: weaponJSON,
+			},
+			expectedType: "*entities.Weapon",
+			validate: func(t *testing.T, eq entities.Equipment) {
+				weapon, ok := eq.(*entities.Weapon)
+				require.True(t, ok)
+				assert.Equal(t, "greataxe", weapon.GetKey())
+			},
+		},
+		{
+			name: "weapon with uppercase type",
+			data: EquipmentData{
+				Type:      "WEAPON",
+				Equipment: weaponJSON,
+			},
+			expectedType: "*entities.Weapon",
+			validate: func(t *testing.T, eq entities.Equipment) {
+				weapon, ok := eq.(*entities.Weapon)
+				require.True(t, ok)
+				assert.Equal(t, "greataxe", weapon.GetKey())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eq, err := DataToEquipmentWithMigration(tt.data)
+			require.NoError(t, err)
+			require.NotNil(t, eq)
+
+			// Check type
+			actualType := fmt.Sprintf("%T", eq)
+			assert.Equal(t, tt.expectedType, actualType)
+
+			// Run validation
+			if tt.validate != nil {
+				tt.validate(t, eq)
+			}
+		})
+	}
+}
+
+func TestEquipmentNilHandling(t *testing.T) {
+	// This test verifies that nil equipment is properly handled
+	// in the toCharacterData function
+	
+	char := &entities.Character{
+		ID:      "test-char",
+		OwnerID: "test-user",
+		RealmID: "test-realm",
+		Name:    "Test Character",
+		EquippedSlots: map[entities.Slot]entities.Equipment{
+			entities.SlotMainHand:  nil, // Nil equipment
+			entities.SlotOffHand:   nil,
+			entities.SlotTwoHanded: &entities.Weapon{
+				Base: entities.BasicEquipment{
+					Key:  "longsword",
+					Name: "Longsword",
+				},
+				WeaponCategory: "martial",
+			},
+		},
+	}
+
+	repo := &redisRepo{}
+	data, err := repo.toCharacterData(char)
+	require.NoError(t, err)
+
+	// Verify that nil equipment slots are not included in the data
+	assert.Len(t, data.EquippedSlots, 1, "Only non-nil equipment should be included")
+	_, hasMainHand := data.EquippedSlots[entities.SlotMainHand]
+	assert.False(t, hasMainHand, "Nil MainHand slot should not be included")
+	_, hasTwoHanded := data.EquippedSlots[entities.SlotTwoHanded]
+	assert.True(t, hasTwoHanded, "Non-nil TwoHanded slot should be included")
+}

--- a/internal/repositories/characters/redis.go
+++ b/internal/repositories/characters/redis.go
@@ -450,6 +450,10 @@ func (r *redisRepo) toCharacterData(char *entities.Character) (*CharacterData, e
 	// Convert equipped slots
 	equippedSlots := make(map[entities.Slot]EquipmentData)
 	for slot, item := range char.EquippedSlots {
+		// Skip nil items (empty slots)
+		if item == nil {
+			continue
+		}
 		data, err := equipmentToData(item)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert equipped item: %w", err)
@@ -490,7 +494,7 @@ func (r *redisRepo) fromCharacterData(data *CharacterData) (*entities.Character,
 	for eqType, items := range data.Inventory {
 		var eqItems []entities.Equipment
 		for _, item := range items {
-			eq, err := dataToEquipment(item)
+			eq, err := DataToEquipmentWithMigration(item)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert inventory data: %w", err)
 			}
@@ -502,7 +506,7 @@ func (r *redisRepo) fromCharacterData(data *CharacterData) (*entities.Character,
 	// Convert equipped slots back
 	equippedSlots := make(map[entities.Slot]entities.Equipment)
 	for slot, item := range data.EquippedSlots {
-		eq, err := dataToEquipment(item)
+		eq, err := DataToEquipmentWithMigration(item)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert equipped data: %w", err)
 		}

--- a/internal/repositories/characters/redis_equipment_migration.go
+++ b/internal/repositories/characters/redis_equipment_migration.go
@@ -8,9 +8,9 @@ import (
 	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
 )
 
-// dataToEquipmentWithMigration converts EquipmentData back to Equipment interface
+// DataToEquipmentWithMigration converts EquipmentData back to Equipment interface
 // with support for legacy data formats
-func dataToEquipmentWithMigration(data EquipmentData) (entities.Equipment, error) {
+func DataToEquipmentWithMigration(data EquipmentData) (entities.Equipment, error) {
 	// Normalize the type to lowercase for legacy compatibility
 	normalizedType := strings.ToLower(data.Type)
 


### PR DESCRIPTION
## Summary
Fixes #54 - Equipment was loading from Redis as `BasicEquipment` instead of the proper type (`Weapon`, `Armor`), causing all attacks to use improvised weapon stats.

## Changes
- ✅ Use `DataToEquipmentWithMigration` function for loading equipment from Redis
- ✅ Skip nil equipment slots during serialization (prevents empty BasicEquipment)
- ✅ Export `DataToEquipmentWithMigration` for better testability
- ✅ Add comprehensive unit tests for equipment type migration
- ✅ Support legacy equipment data with empty or unknown type fields

## Test Results
All unit tests pass:
```
=== RUN   TestDataToEquipmentWithMigration
=== RUN   TestDataToEquipmentWithMigration/weapon_with_correct_type
=== RUN   TestDataToEquipmentWithMigration/weapon_with_empty_type_(legacy)
=== RUN   TestDataToEquipmentWithMigration/weapon_with_unknown_type
=== RUN   TestDataToEquipmentWithMigration/weapon_with_uppercase_type
--- PASS: TestDataToEquipmentWithMigration (0.00s)
```

## Impact
- Weapons now properly load with their damage dice (e.g., greataxe does 1d12 instead of 1d4)
- Legacy equipment data is automatically migrated
- No data loss or corruption

🤖 Generated with [Claude Code](https://claude.ai/code)