### PR TITLE
feat: Add interactive character sheet display command

### DIFF
--- a/internal/handlers/discord/dnd/character/sheet.go
+++ b/internal/handlers/discord/dnd/character/sheet.go
@@ -1,0 +1,254 @@
+package character
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/services"
+	"github.com/bwmarrin/discordgo"
+)
+
+// SheetHandler handles the character sheet display command
+type SheetHandler struct {
+	services *services.Provider
+}
+
+// NewSheetHandler creates a new sheet handler
+func NewSheetHandler(serviceProvider *services.Provider) *SheetHandler {
+	return &SheetHandler{
+		services: serviceProvider,
+	}
+}
+
+// Handle processes the character sheet command
+func (h *SheetHandler) Handle(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	// Get character ID from options
+	var characterID string
+	for _, option := range i.ApplicationCommandData().Options[0].Options[0].Options {
+		if option.Name == "character_id" {
+			characterID = option.StringValue()
+			break
+		}
+	}
+
+	if characterID == "" {
+		return respondWithError(s, i, "Character ID is required")
+	}
+
+	// Get the character from service (all business logic is in the service)
+	character, err := h.services.CharacterService.GetByID(characterID)
+	if err != nil {
+		log.Printf("Error getting character %s: %v", characterID, err)
+		return respondWithError(s, i, "Character not found")
+	}
+
+	// Verify ownership
+	if character.OwnerID != i.Member.User.ID {
+		return respondWithError(s, i, "You can only view your own characters!")
+	}
+
+	// Build the character sheet embed (pure presentation logic)
+	embed := BuildCharacterSheetEmbed(character)
+	
+	// Build interactive components
+	components := BuildCharacterSheetComponents(characterID)
+
+	// Send ephemeral response
+	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds:     []*discordgo.MessageEmbed{embed},
+			Components: components,
+			Flags:      discordgo.MessageFlagsEphemeral, // Only visible to the user
+		},
+	})
+}
+
+// BuildCharacterSheetEmbed creates the main character sheet embed
+func BuildCharacterSheetEmbed(char *entities.Character) *discordgo.MessageEmbed {
+	// Build title
+	title := fmt.Sprintf("%s - Level %d %s", char.Name, char.Level, char.Class.Name)
+	if char.Race != nil {
+		title = fmt.Sprintf("%s %s", char.Race.Name, title)
+	}
+
+	// Build HP/AC line
+	hpAcLine := fmt.Sprintf("**HP:** %d/%d | **AC:** %d", 
+		char.CurrentHitPoints, char.MaxHitPoints, char.AC)
+	
+	// Calculate initiative bonus
+	initiativeBonus := 0
+	if dex, exists := char.Attributes[entities.AttributeDexterity]; exists {
+		initiativeBonus = dex.Bonus
+	}
+	hpAcLine += fmt.Sprintf(" | **Initiative:** %+d", initiativeBonus)
+
+	// Build ability scores
+	abilityLines := []string{
+		"**Physical:**",
+		buildAbilityLine("STR", char.Attributes[entities.AttributeStrength]),
+		buildAbilityLine("DEX", char.Attributes[entities.AttributeDexterity]),
+		buildAbilityLine("CON", char.Attributes[entities.AttributeConstitution]),
+		"",
+		"**Mental:**",
+		buildAbilityLine("INT", char.Attributes[entities.AttributeIntelligence]),
+		buildAbilityLine("WIS", char.Attributes[entities.AttributeWisdom]),
+		buildAbilityLine("CHA", char.Attributes[entities.AttributeCharisma]),
+	}
+
+	// Build equipment display
+	equipmentLines := buildEquipmentDisplay(char)
+
+	// Build proficiencies summary
+	proficiencyLines := buildProficiencySummary(char)
+
+	embed := &discordgo.MessageEmbed{
+		Title:       title,
+		Description: hpAcLine,
+		Color:       0x3498db, // Blue
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "📊 Ability Scores",
+				Value:  strings.Join(abilityLines, "\n"),
+				Inline: true,
+			},
+			{
+				Name:   "⚔️ Equipment",
+				Value:  strings.Join(equipmentLines, "\n"),
+				Inline: true,
+			},
+			{
+				Name:   "📚 Proficiencies",
+				Value:  strings.Join(proficiencyLines, "\n"),
+				Inline: false,
+			},
+		},
+		Footer: &discordgo.MessageEmbedFooter{
+			Text: fmt.Sprintf("Character ID: %s", char.ID),
+		},
+	}
+
+	return embed
+}
+
+// buildAbilityLine formats a single ability score line
+func buildAbilityLine(name string, score *entities.AbilityScore) string {
+	if score == nil {
+		return fmt.Sprintf("**%s:** 10 (+0)", name)
+	}
+	return fmt.Sprintf("**%s:** %d (%+d)", name, score.Score, score.Bonus)
+}
+
+// buildEquipmentDisplay builds the equipment section
+func buildEquipmentDisplay(char *entities.Character) []string {
+	lines := []string{}
+
+	// Main hand
+	if weapon := char.EquippedSlots[entities.SlotMainHand]; weapon != nil {
+		lines = append(lines, fmt.Sprintf("**Main Hand:** %s", weapon.GetName()))
+	} else {
+		lines = append(lines, "**Main Hand:** Empty")
+	}
+
+	// Off hand
+	if item := char.EquippedSlots[entities.SlotOffHand]; item != nil {
+		lines = append(lines, fmt.Sprintf("**Off Hand:** %s", item.GetName()))
+	} else {
+		lines = append(lines, "**Off Hand:** Empty")
+	}
+
+	// Two-handed (only show if no main/off hand)
+	if char.EquippedSlots[entities.SlotMainHand] == nil && char.EquippedSlots[entities.SlotOffHand] == nil {
+		if weapon := char.EquippedSlots[entities.SlotTwoHanded]; weapon != nil {
+			lines = append(lines, fmt.Sprintf("**Two-Handed:** %s", weapon.GetName()))
+		}
+	}
+
+	// Armor
+	if armor := char.EquippedSlots[entities.SlotBody]; armor != nil {
+		lines = append(lines, fmt.Sprintf("**Armor:** %s", armor.GetName()))
+	} else {
+		lines = append(lines, "**Armor:** None")
+	}
+
+	return lines
+}
+
+// buildProficiencySummary builds a summary of proficiencies
+func buildProficiencySummary(char *entities.Character) []string {
+	lines := []string{}
+
+	// Weapon proficiencies
+	if weapons, exists := char.Proficiencies[entities.ProficiencyTypeWeapon]; exists && len(weapons) > 0 {
+		weaponNames := []string{}
+		for _, prof := range weapons {
+			weaponNames = append(weaponNames, prof.Name)
+		}
+		lines = append(lines, fmt.Sprintf("**Weapons:** %s", strings.Join(weaponNames, ", ")))
+	}
+
+	// Armor proficiencies
+	if armors, exists := char.Proficiencies[entities.ProficiencyTypeArmor]; exists && len(armors) > 0 {
+		armorNames := []string{}
+		for _, prof := range armors {
+			armorNames = append(armorNames, prof.Name)
+		}
+		lines = append(lines, fmt.Sprintf("**Armor:** %s", strings.Join(armorNames, ", ")))
+	}
+
+	// Skill proficiencies
+	if skills, exists := char.Proficiencies[entities.ProficiencyTypeSkill]; exists && len(skills) > 0 {
+		skillNames := []string{}
+		for _, prof := range skills {
+			skillNames = append(skillNames, prof.Name)
+		}
+		lines = append(lines, fmt.Sprintf("**Skills:** %s", strings.Join(skillNames, ", ")))
+	}
+
+	if len(lines) == 0 {
+		lines = append(lines, "*No proficiencies*")
+	}
+
+	return lines
+}
+
+// BuildCharacterSheetComponents builds the interactive buttons
+func BuildCharacterSheetComponents(characterID string) []discordgo.MessageComponent {
+	return []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.Button{
+					Label:    "View Inventory",
+					Style:    discordgo.PrimaryButton,
+					CustomID: fmt.Sprintf("character:inventory:%s", characterID),
+					Emoji:    &discordgo.ComponentEmoji{Name: "🎒"},
+				},
+				discordgo.Button{
+					Label:    "View Details",
+					Style:    discordgo.SecondaryButton,
+					CustomID: fmt.Sprintf("character:details:%s", characterID),
+					Emoji:    &discordgo.ComponentEmoji{Name: "📋"},
+				},
+				discordgo.Button{
+					Label:    "Refresh",
+					Style:    discordgo.SecondaryButton,
+					CustomID: fmt.Sprintf("character:sheet_refresh:%s", characterID),
+					Emoji:    &discordgo.ComponentEmoji{Name: "🔄"},
+				},
+			},
+		},
+	}
+}
+
+// respondWithError sends an error message as ephemeral
+func respondWithError(s *discordgo.Session, i *discordgo.InteractionCreate, message string) error {
+	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("❌ %s", message),
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+}

--- a/internal/handlers/discord/dnd/character/sheet_test.go
+++ b/internal/handlers/discord/dnd/character/sheet_test.go
@@ -1,0 +1,113 @@
+package character
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCharacterSheetEmbed(t *testing.T) {
+	// Create a test character
+	char := &entities.Character{
+		ID:               "test-char-1",
+		Name:             "Aragorn",
+		Level:            5,
+		CurrentHitPoints: 45,
+		MaxHitPoints:     45,
+		AC:               16,
+		Class: &entities.Class{
+			Name: "Ranger",
+		},
+		Race: &entities.Race{
+			Name: "Human",
+		},
+		Attributes: map[entities.Attribute]*entities.AbilityScore{
+			entities.AttributeStrength:     {Score: 16, Bonus: 3},
+			entities.AttributeDexterity:    {Score: 14, Bonus: 2},
+			entities.AttributeConstitution: {Score: 14, Bonus: 2},
+			entities.AttributeIntelligence: {Score: 12, Bonus: 1},
+			entities.AttributeWisdom:       {Score: 13, Bonus: 1},
+			entities.AttributeCharisma:     {Score: 10, Bonus: 0},
+		},
+		EquippedSlots: map[entities.Slot]entities.Equipment{
+			entities.SlotMainHand: &entities.Weapon{
+				Base: entities.BasicEquipment{
+					Key:  "longsword",
+					Name: "Longsword",
+				},
+			},
+			entities.SlotBody: &entities.Armor{
+				Base: entities.BasicEquipment{
+					Key:  "chain_mail",
+					Name: "Chain Mail",
+				},
+			},
+		},
+		Proficiencies: map[entities.ProficiencyType][]*entities.Proficiency{
+			entities.ProficiencyTypeWeapon: {
+				{Key: "simple-weapons", Name: "Simple Weapons"},
+				{Key: "martial-weapons", Name: "Martial Weapons"},
+			},
+			entities.ProficiencyTypeArmor: {
+				{Key: "light-armor", Name: "Light Armor"},
+				{Key: "medium-armor", Name: "Medium Armor"},
+				{Key: "shields", Name: "Shields"},
+			},
+			entities.ProficiencyTypeSkill: {
+				{Key: "survival", Name: "Survival"},
+				{Key: "perception", Name: "Perception"},
+			},
+		},
+	}
+
+	embed := BuildCharacterSheetEmbed(char)
+
+	// Verify embed properties
+	assert.Equal(t, "Human Aragorn - Level 5 Ranger", embed.Title)
+	assert.Contains(t, embed.Description, "**HP:** 45/45")
+	assert.Contains(t, embed.Description, "**AC:** 16")
+	assert.Contains(t, embed.Description, "**Initiative:** +2")
+
+	// Verify fields
+	require.Len(t, embed.Fields, 3)
+	
+	// Check ability scores field
+	assert.Equal(t, "📊 Ability Scores", embed.Fields[0].Name)
+	assert.Contains(t, embed.Fields[0].Value, "**STR:** 16 (+3)")
+	assert.Contains(t, embed.Fields[0].Value, "**DEX:** 14 (+2)")
+
+	// Check equipment field
+	assert.Equal(t, "⚔️ Equipment", embed.Fields[1].Name)
+	assert.Contains(t, embed.Fields[1].Value, "**Main Hand:** Longsword")
+	assert.Contains(t, embed.Fields[1].Value, "**Armor:** Chain Mail")
+
+	// Check proficiencies field
+	assert.Equal(t, "📚 Proficiencies", embed.Fields[2].Name)
+	assert.Contains(t, embed.Fields[2].Value, "**Weapons:** Simple Weapons, Martial Weapons")
+	assert.Contains(t, embed.Fields[2].Value, "**Skills:** Survival, Perception")
+}
+
+func TestBuildCharacterSheetComponents(t *testing.T) {
+	characterID := "test-char-123"
+	components := BuildCharacterSheetComponents(characterID)
+
+	require.Len(t, components, 1)
+	
+	// Check that we have an action row
+	actionRow, ok := components[0].(discordgo.ActionsRow)
+	require.True(t, ok)
+	require.Len(t, actionRow.Components, 3)
+
+	// Verify button custom IDs
+	button1 := actionRow.Components[0].(discordgo.Button)
+	assert.Equal(t, "character:inventory:test-char-123", button1.CustomID)
+	
+	button2 := actionRow.Components[1].(discordgo.Button)
+	assert.Equal(t, "character:details:test-char-123", button2.CustomID)
+	
+	button3 := actionRow.Components[2].(discordgo.Button)
+	assert.Equal(t, "character:sheet_refresh:test-char-123", button3.CustomID)
+}


### PR DESCRIPTION
## Summary
Implements #37 - Adds an interactive `/dnd character sheet` command that displays a comprehensive character sheet as an ephemeral message.

## Implementation Details
- ✅ New slash command: `/dnd character sheet <character_id>`
- ✅ Ephemeral response (only visible to requesting player)
- ✅ Clean architecture: handler manages presentation, service handles data
- ✅ Comprehensive display includes:
  - Character name, level, race, and class
  - HP, AC, and initiative modifier
  - All six ability scores with modifiers
  - Equipped items in each slot
  - Weapon, armor, and skill proficiencies
- ✅ Interactive buttons for future expansion:
  - View Inventory
  - View Details  
  - Refresh (updates the sheet with latest data)

## Example Output
```
Human Aragorn - Level 5 Ranger
HP: 45/45 | AC: 16 | Initiative: +2

📊 Ability Scores        ⚔️ Equipment
Physical:                Main Hand: Longsword
STR: 16 (+3)            Off Hand: Empty
DEX: 14 (+2)            Armor: Chain Mail
CON: 14 (+2)

Mental:
INT: 12 (+1)
WIS: 13 (+1)
CHA: 10 (+0)

📚 Proficiencies
Weapons: Simple Weapons, Martial Weapons
Armor: Light Armor, Medium Armor, Shields
Skills: Survival, Perception
```

## Testing
- Added comprehensive unit tests for embed building
- Tests verify all display elements are formatted correctly
- Tests ensure interactive components have correct IDs

## Architecture Notes
This implementation demonstrates the correct pattern for Discord handlers:
- Handler (`sheet.go`) only handles Discord interaction and presentation
- All business logic stays in the character service
- Exported helper functions allow button handlers to rebuild the sheet

🤖 Generated with [Claude Code](https://claude.ai/code)