### PR TITLE
Fix ability scores parsing error during proficiency selection

### DIFF
--- a/internal/handlers/discord/handler.go
+++ b/internal/handlers/discord/handler.go
@@ -795,7 +795,7 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 					i.Member.User.ID,
 					i.GuildID,
 				)
-				
+
 				// If we already have ability scores, skip parsing and go straight to proficiencies
 				if err == nil && draftChar.Attributes != nil && len(draftChar.Attributes) == 6 {
 					log.Printf("Ability scores already saved, moving to proficiencies")
@@ -810,7 +810,7 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 					}
 					return
 				}
-				
+
 				// Parse ability scores from the current message embed
 				abilityScores := make(map[string]int)
 				if i.Message != nil && len(i.Message.Embeds) > 0 {

--- a/internal/handlers/discord/handler.go
+++ b/internal/handlers/discord/handler.go
@@ -789,6 +789,28 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 		case "confirm_abilities":
 			// Save ability scores to draft character before moving to proficiency choices
 			if len(parts) >= 4 {
+				// First check if we already have ability scores saved
+				draftChar, err := h.ServiceProvider.CharacterService.GetOrCreateDraftCharacter(
+					context.Background(),
+					i.Member.User.ID,
+					i.GuildID,
+				)
+				
+				// If we already have ability scores, skip parsing and go straight to proficiencies
+				if err == nil && draftChar.Attributes != nil && len(draftChar.Attributes) == 6 {
+					log.Printf("Ability scores already saved, moving to proficiencies")
+					req := &character.ProficiencyChoicesRequest{
+						Session:     s,
+						Interaction: i,
+						RaceKey:     parts[2],
+						ClassKey:    parts[3],
+					}
+					if err := h.characterProficiencyChoicesHandler.Handle(req); err != nil {
+						log.Printf("Error handling confirm abilities: %v", err)
+					}
+					return
+				}
+				
 				// Parse ability scores from the current message embed
 				abilityScores := make(map[string]int)
 				if i.Message != nil && len(i.Message.Embeds) > 0 {


### PR DESCRIPTION
## Summary
- Fixed issue #71 where ability scores parsing error prevented Rogue character creation
- Added check to skip redundant ability score parsing if already saved
- Prevents "Parsed ability scores: map[]" error during character creation flow

## Problem
When clicking "Confirm & Continue" after assigning ability scores, the handler would:
1. Successfully parse and save ability scores
2. Update the message to show proficiency choices
3. Try to parse ability scores again from the updated message (which no longer contains them)
4. Log an error about empty ability scores

## Solution
Added an early check in the `confirm_abilities` handler to skip parsing if ability scores are already saved in the draft character. This prevents the redundant parsing attempt and eliminates the error.

## Test plan
- [x] Create a new Rogue character
- [x] Assign ability scores and click "Confirm & Continue"
- [x] Verify no "empty ability scores" error appears
- [x] Successfully select proficiencies
- [x] Continue to equipment selection without issues

Fixes #71

🤖 Generated with [Claude Code](https://claude.ai/code)