### PR TITLE
Fix: Proficiency duplication bug in character creation

### DIFF
--- a/internal/entities/character.go
+++ b/internal/entities/character.go
@@ -420,12 +420,33 @@ func (c *Character) AddProficiency(p *Proficiency) {
 		c.Proficiencies = make(map[ProficiencyType][]*Proficiency)
 	}
 	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.Proficiencies[p.Type] == nil {
 		c.Proficiencies[p.Type] = make([]*Proficiency, 0)
 	}
 
+	// Check for duplicates
+	for _, existing := range c.Proficiencies[p.Type] {
+		if existing.Key == p.Key {
+			return // Already have this proficiency
+		}
+	}
+
 	c.Proficiencies[p.Type] = append(c.Proficiencies[p.Type], p)
-	c.mu.Unlock()
+}
+
+// SetProficiencies replaces all proficiencies of a given type
+// This is used when selecting proficiencies during character creation
+func (c *Character) SetProficiencies(profType ProficiencyType, proficiencies []*Proficiency) {
+	if c.Proficiencies == nil {
+		c.Proficiencies = make(map[ProficiencyType][]*Proficiency)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Replace all proficiencies of this type
+	c.Proficiencies[profType] = proficiencies
 }
 
 func (c *Character) AddAbilityScoreBonus(attr Attribute, bonus int) {

--- a/internal/entities/character_proficiency_fix_test.go
+++ b/internal/entities/character_proficiency_fix_test.go
@@ -1,0 +1,119 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCharacterProficiencyDuplicationBug reproduces issue #73
+func TestCharacterProficiencyDuplicationBug(t *testing.T) {
+	t.Run("AddProficiency should not add duplicates", func(t *testing.T) {
+		char := &Character{
+			Proficiencies: make(map[ProficiencyType][]*Proficiency),
+		}
+
+		// Add a proficiency
+		prof := &Proficiency{
+			Key:  "skill-acrobatics",
+			Name: "Acrobatics",
+			Type: ProficiencyTypeSkill,
+		}
+		char.AddProficiency(prof)
+
+		// Try to add the same proficiency again
+		char.AddProficiency(prof)
+
+		// Should only have one instance
+		assert.Len(t, char.Proficiencies[ProficiencyTypeSkill], 1, "Should not have duplicate proficiencies")
+	})
+
+	t.Run("SetProficiencies should replace proficiencies of same type", func(t *testing.T) {
+		char := &Character{
+			Proficiencies: make(map[ProficiencyType][]*Proficiency),
+		}
+
+		// Add initial proficiencies
+		initial := []*Proficiency{
+			{Key: "skill-acrobatics", Name: "Acrobatics", Type: ProficiencyTypeSkill},
+			{Key: "skill-athletics", Name: "Athletics", Type: ProficiencyTypeSkill},
+		}
+		for _, p := range initial {
+			char.AddProficiency(p)
+		}
+
+		// Now set new proficiencies (simulating a new selection)
+		newProfs := []*Proficiency{
+			{Key: "skill-perception", Name: "Perception", Type: ProficiencyTypeSkill},
+			{Key: "skill-stealth", Name: "Stealth", Type: ProficiencyTypeSkill},
+		}
+		char.SetProficiencies(ProficiencyTypeSkill, newProfs)
+
+		// Should only have the new proficiencies
+		assert.Len(t, char.Proficiencies[ProficiencyTypeSkill], 2)
+		assert.Equal(t, "skill-perception", char.Proficiencies[ProficiencyTypeSkill][0].Key)
+		assert.Equal(t, "skill-stealth", char.Proficiencies[ProficiencyTypeSkill][1].Key)
+	})
+
+	t.Run("Mixed proficiency types should be preserved", func(t *testing.T) {
+		char := &Character{
+			Proficiencies: make(map[ProficiencyType][]*Proficiency),
+		}
+
+		// Add different types of proficiencies
+		char.AddProficiency(&Proficiency{Key: "armor-light", Name: "Light Armor", Type: ProficiencyTypeArmor})
+		char.AddProficiency(&Proficiency{Key: "weapon-simple", Name: "Simple Weapons", Type: ProficiencyTypeWeapon})
+		char.AddProficiency(&Proficiency{Key: "skill-athletics", Name: "Athletics", Type: ProficiencyTypeSkill})
+
+		// Replace only skill proficiencies
+		newSkills := []*Proficiency{
+			{Key: "skill-perception", Name: "Perception", Type: ProficiencyTypeSkill},
+		}
+		char.SetProficiencies(ProficiencyTypeSkill, newSkills)
+
+		// Other proficiency types should be preserved
+		assert.Len(t, char.Proficiencies[ProficiencyTypeArmor], 1)
+		assert.Len(t, char.Proficiencies[ProficiencyTypeWeapon], 1)
+		assert.Len(t, char.Proficiencies[ProficiencyTypeSkill], 1)
+		assert.Equal(t, "skill-perception", char.Proficiencies[ProficiencyTypeSkill][0].Key)
+	})
+}
+
+// TestProficiencyChoiceCategories tests that we can distinguish between base and chosen proficiencies
+func TestProficiencyChoiceCategories(t *testing.T) {
+	t.Run("Should distinguish base proficiencies from chosen ones", func(t *testing.T) {
+		char := &Character{
+			Proficiencies: make(map[ProficiencyType][]*Proficiency),
+		}
+
+		// Base proficiencies from race/class (these should be preserved)
+		baseProfs := []*Proficiency{
+			{Key: "armor-light", Name: "Light Armor", Type: ProficiencyTypeArmor},
+			{Key: "weapon-simple", Name: "Simple Weapons", Type: ProficiencyTypeWeapon},
+			{Key: "saving-throw-dex", Name: "Dexterity", Type: ProficiencyTypeSavingThrow},
+			{Key: "saving-throw-int", Name: "Intelligence", Type: ProficiencyTypeSavingThrow},
+		}
+
+		// Add base proficiencies
+		for _, p := range baseProfs {
+			char.AddProficiency(p)
+		}
+
+		// Chosen skill proficiencies (these should be replaceable)
+		chosenSkills := []*Proficiency{
+			{Key: "skill-acrobatics", Name: "Acrobatics", Type: ProficiencyTypeSkill},
+			{Key: "skill-stealth", Name: "Stealth", Type: ProficiencyTypeSkill},
+		}
+
+		// Set chosen skills
+		char.SetProficiencies(ProficiencyTypeSkill, chosenSkills)
+
+		// Verify base proficiencies are preserved
+		assert.Len(t, char.Proficiencies[ProficiencyTypeArmor], 1)
+		assert.Len(t, char.Proficiencies[ProficiencyTypeWeapon], 1)
+		assert.Len(t, char.Proficiencies[ProficiencyTypeSavingThrow], 2)
+
+		// Verify chosen skills are set correctly
+		assert.Len(t, char.Proficiencies[ProficiencyTypeSkill], 2)
+	})
+}

--- a/internal/handlers/discord/proficiency_bug_test.go
+++ b/internal/handlers/discord/proficiency_bug_test.go
@@ -1,0 +1,75 @@
+package discord
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProficiencyCustomIDParsing tests that the proficiency confirmation custom ID is parsed correctly
+func TestProficiencyCustomIDParsing(t *testing.T) {
+	tests := []struct {
+		name          string
+		customID      string
+		expectedParts int
+		shouldHandle  bool
+	}{
+		{
+			name:          "Valid proficiency confirmation",
+			customID:      "character_create:confirm_proficiency:human:rogue:class:0",
+			expectedParts: 6,
+			shouldHandle:  true,
+		},
+		{
+			name:          "Too few parts",
+			customID:      "character_create:confirm_proficiency:human:rogue",
+			expectedParts: 4,
+			shouldHandle:  false,
+		},
+		{
+			name:          "Different action",
+			customID:      "character_create:select_proficiencies:human:rogue",
+			expectedParts: 4,
+			shouldHandle:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parts := strings.Split(tt.customID, ":")
+			assert.Equal(t, tt.expectedParts, len(parts), "Parts length mismatch")
+
+			// Check if it should be handled by confirm_proficiency case
+			if len(parts) >= 2 {
+				action := parts[1]
+				willHandle := action == "confirm_proficiency" && len(parts) >= 6
+				assert.Equal(t, tt.shouldHandle, willHandle,
+					"Handler mismatch for action %s with %d parts", action, len(parts))
+			}
+		})
+	}
+}
+
+// TestDebugProficiencyFlow helps debug the actual flow
+func TestDebugProficiencyFlow(t *testing.T) {
+	// This test logs what's happening to help debug
+	customID := "character_create:confirm_proficiency:human:rogue:class:0"
+	parts := strings.Split(customID, ":")
+
+	t.Logf("Custom ID: %s", customID)
+	t.Logf("Parts: %v", parts)
+	t.Logf("Parts length: %d", len(parts))
+	t.Logf("Action (parts[1]): %s", parts[1])
+
+	if len(parts) >= 6 {
+		t.Logf("Race (parts[2]): %s", parts[2])
+		t.Logf("Class (parts[3]): %s", parts[3])
+		t.Logf("Choice Type (parts[4]): %s", parts[4])
+		t.Logf("Choice Index (parts[5]): %s", parts[5])
+	}
+
+	// Verify this matches what the handler expects
+	assert.Equal(t, "confirm_proficiency", parts[1])
+	assert.Equal(t, 6, len(parts))
+}

--- a/internal/services/character/proficiency_duplication_integration_test.go
+++ b/internal/services/character/proficiency_duplication_integration_test.go
@@ -1,0 +1,144 @@
+package character_test
+
+import (
+	"context"
+	"testing"
+
+	mockdnd5e "github.com/KirkDiggler/dnd-bot-discord/internal/clients/dnd5e/mock"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	mockcharrepo "github.com/KirkDiggler/dnd-bot-discord/internal/repositories/characters/mock"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/services/character"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// TestProficiencyDuplicationBugIntegration tests the full flow that causes issue #73
+func TestProficiencyDuplicationBugIntegration(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Multiple updates with same skills should not accumulate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockDNDClient := mockdnd5e.NewMockClient(ctrl)
+		mockRepo := mockcharrepo.NewMockRepository(ctrl)
+
+		service := character.NewService(&character.ServiceConfig{
+			DNDClient:  mockDNDClient,
+			Repository: mockRepo,
+		})
+
+		// Create a rogue character with base proficiencies
+		char := &entities.Character{
+			ID:      "test-rogue",
+			OwnerID: "test-user",
+			RealmID: "test-realm",
+			Status:  entities.CharacterStatusDraft,
+			Race: &entities.Race{
+				Key:  "human",
+				Name: "Human",
+			},
+			Class: &entities.Class{
+				Key:  "rogue",
+				Name: "Rogue",
+			},
+			Proficiencies: map[entities.ProficiencyType][]*entities.Proficiency{
+				// Base proficiencies from rogue class
+				entities.ProficiencyTypeArmor: {
+					{Key: "armor-light", Name: "Light Armor", Type: entities.ProficiencyTypeArmor},
+				},
+				entities.ProficiencyTypeWeapon: {
+					{Key: "weapon-simple", Name: "Simple Weapons", Type: entities.ProficiencyTypeWeapon},
+					{Key: "weapon-shortsword", Name: "Shortsword", Type: entities.ProficiencyTypeWeapon},
+				},
+				entities.ProficiencyTypeSavingThrow: {
+					{Key: "saving-throw-dex", Name: "Dexterity", Type: entities.ProficiencyTypeSavingThrow},
+					{Key: "saving-throw-int", Name: "Intelligence", Type: entities.ProficiencyTypeSavingThrow},
+				},
+			},
+		}
+
+		// First skill selection
+		mockRepo.EXPECT().Get(ctx, "test-rogue").Return(char, nil)
+		mockRepo.EXPECT().Update(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, c *entities.Character) error {
+			// Verify skills were set correctly
+			assert.Len(t, c.Proficiencies[entities.ProficiencyTypeSkill], 4)
+			return nil
+		})
+
+		// Mock proficiency lookups
+		mockDNDClient.EXPECT().GetProficiency("skill-acrobatics").Return(
+			&entities.Proficiency{Key: "skill-acrobatics", Name: "Acrobatics", Type: entities.ProficiencyTypeSkill}, nil)
+		mockDNDClient.EXPECT().GetProficiency("skill-stealth").Return(
+			&entities.Proficiency{Key: "skill-stealth", Name: "Stealth", Type: entities.ProficiencyTypeSkill}, nil)
+		mockDNDClient.EXPECT().GetProficiency("skill-perception").Return(
+			&entities.Proficiency{Key: "skill-perception", Name: "Perception", Type: entities.ProficiencyTypeSkill}, nil)
+		mockDNDClient.EXPECT().GetProficiency("skill-investigation").Return(
+			&entities.Proficiency{Key: "skill-investigation", Name: "Investigation", Type: entities.ProficiencyTypeSkill}, nil)
+
+		// First update - selecting 4 skills
+		updatedChar, err := service.UpdateDraftCharacter(ctx, "test-rogue", &character.UpdateDraftInput{
+			Proficiencies: []string{
+				"skill-acrobatics",
+				"skill-stealth",
+				"skill-perception",
+				"skill-investigation",
+			},
+		})
+		assert.NoError(t, err)
+		assert.Len(t, updatedChar.Proficiencies[entities.ProficiencyTypeSkill], 4)
+
+		// Second skill selection - simulating user changing their mind
+		mockRepo.EXPECT().Get(ctx, "test-rogue").Return(updatedChar, nil)
+		mockRepo.EXPECT().Update(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, c *entities.Character) error {
+			// Verify skills were replaced, not accumulated
+			assert.Len(t, c.Proficiencies[entities.ProficiencyTypeSkill], 4, "Skills should be replaced, not accumulated")
+
+			// Verify base proficiencies are preserved
+			assert.Len(t, c.Proficiencies[entities.ProficiencyTypeArmor], 1)
+			assert.Len(t, c.Proficiencies[entities.ProficiencyTypeWeapon], 2)
+			assert.Len(t, c.Proficiencies[entities.ProficiencyTypeSavingThrow], 2)
+			return nil
+		})
+
+		// Mock new proficiency lookups
+		mockDNDClient.EXPECT().GetProficiency("skill-sleight-of-hand").Return(
+			&entities.Proficiency{Key: "skill-sleight-of-hand", Name: "Sleight of Hand", Type: entities.ProficiencyTypeSkill}, nil)
+		mockDNDClient.EXPECT().GetProficiency("skill-deception").Return(
+			&entities.Proficiency{Key: "skill-deception", Name: "Deception", Type: entities.ProficiencyTypeSkill}, nil)
+		mockDNDClient.EXPECT().GetProficiency("skill-insight").Return(
+			&entities.Proficiency{Key: "skill-insight", Name: "Insight", Type: entities.ProficiencyTypeSkill}, nil)
+		mockDNDClient.EXPECT().GetProficiency("skill-intimidation").Return(
+			&entities.Proficiency{Key: "skill-intimidation", Name: "Intimidation", Type: entities.ProficiencyTypeSkill}, nil)
+
+		// Second update - changing to different skills
+		finalChar, err := service.UpdateDraftCharacter(ctx, "test-rogue", &character.UpdateDraftInput{
+			Proficiencies: []string{
+				"skill-sleight-of-hand",
+				"skill-deception",
+				"skill-insight",
+				"skill-intimidation",
+			},
+		})
+		assert.NoError(t, err)
+
+		// Final verification
+		assert.Len(t, finalChar.Proficiencies[entities.ProficiencyTypeSkill], 4, "Should have exactly 4 skills")
+
+		// Check the actual skills
+		skillKeys := make(map[string]bool)
+		for _, prof := range finalChar.Proficiencies[entities.ProficiencyTypeSkill] {
+			skillKeys[prof.Key] = true
+		}
+		assert.True(t, skillKeys["skill-sleight-of-hand"])
+		assert.True(t, skillKeys["skill-deception"])
+		assert.True(t, skillKeys["skill-insight"])
+		assert.True(t, skillKeys["skill-intimidation"])
+
+		// Old skills should not be present
+		assert.False(t, skillKeys["skill-acrobatics"])
+		assert.False(t, skillKeys["skill-stealth"])
+		assert.False(t, skillKeys["skill-perception"])
+		assert.False(t, skillKeys["skill-investigation"])
+	})
+}

--- a/internal/services/character/proficiency_update_test.go
+++ b/internal/services/character/proficiency_update_test.go
@@ -1,0 +1,95 @@
+package character_test
+
+import (
+	"context"
+	"testing"
+
+	mockdnd5e "github.com/KirkDiggler/dnd-bot-discord/internal/clients/dnd5e/mock"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	mockcharrepo "github.com/KirkDiggler/dnd-bot-discord/internal/repositories/characters/mock"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/services/character"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// TestProficiencyUpdateHandling tests the fix for issue #73
+func TestProficiencyUpdateHandling(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Updating proficiencies should replace skill proficiencies only", func(t *testing.T) {
+		// Setup
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockDNDClient := mockdnd5e.NewMockClient(ctrl)
+		mockRepo := mockcharrepo.NewMockRepository(ctrl)
+
+		service := character.NewService(&character.ServiceConfig{
+			DNDClient:  mockDNDClient,
+			Repository: mockRepo,
+		})
+
+		// Create a character with base proficiencies
+		char := &entities.Character{
+			ID:      "test-char-1",
+			OwnerID: "test-user",
+			RealmID: "test-realm",
+			Status:  entities.CharacterStatusDraft,
+			Proficiencies: map[entities.ProficiencyType][]*entities.Proficiency{
+				// Base proficiencies from class
+				entities.ProficiencyTypeArmor: {
+					{Key: "armor-light", Name: "Light Armor", Type: entities.ProficiencyTypeArmor},
+				},
+				entities.ProficiencyTypeWeapon: {
+					{Key: "weapon-simple", Name: "Simple Weapons", Type: entities.ProficiencyTypeWeapon},
+				},
+				entities.ProficiencyTypeSavingThrow: {
+					{Key: "saving-throw-dex", Name: "Dexterity", Type: entities.ProficiencyTypeSavingThrow},
+					{Key: "saving-throw-int", Name: "Intelligence", Type: entities.ProficiencyTypeSavingThrow},
+				},
+				// Previously chosen skills
+				entities.ProficiencyTypeSkill: {
+					{Key: "skill-acrobatics", Name: "Acrobatics", Type: entities.ProficiencyTypeSkill},
+					{Key: "skill-stealth", Name: "Stealth", Type: entities.ProficiencyTypeSkill},
+				},
+			},
+		}
+
+		// Mock repository calls
+		mockRepo.EXPECT().Get(ctx, "test-char-1").Return(char, nil)
+		mockRepo.EXPECT().Update(ctx, gomock.Any()).Return(nil)
+
+		// Mock proficiency lookups for new selections
+		mockDNDClient.EXPECT().GetProficiency("skill-perception").Return(
+			&entities.Proficiency{Key: "skill-perception", Name: "Perception", Type: entities.ProficiencyTypeSkill}, nil)
+		mockDNDClient.EXPECT().GetProficiency("skill-investigation").Return(
+			&entities.Proficiency{Key: "skill-investigation", Name: "Investigation", Type: entities.ProficiencyTypeSkill}, nil)
+
+		// Update with new skill selections
+		updates := &character.UpdateDraftInput{
+			Proficiencies: []string{"skill-perception", "skill-investigation"},
+		}
+
+		updatedChar, err := service.UpdateDraftCharacter(ctx, "test-char-1", updates)
+		assert.NoError(t, err)
+		assert.NotNil(t, updatedChar)
+
+		// Verify base proficiencies are preserved
+		assert.Len(t, updatedChar.Proficiencies[entities.ProficiencyTypeArmor], 1)
+		assert.Len(t, updatedChar.Proficiencies[entities.ProficiencyTypeWeapon], 1)
+		assert.Len(t, updatedChar.Proficiencies[entities.ProficiencyTypeSavingThrow], 2)
+
+		// Verify skill proficiencies were replaced (not accumulated)
+		assert.Len(t, updatedChar.Proficiencies[entities.ProficiencyTypeSkill], 2)
+
+		// Check the actual skills
+		skillKeys := make([]string, 0)
+		for _, prof := range updatedChar.Proficiencies[entities.ProficiencyTypeSkill] {
+			skillKeys = append(skillKeys, prof.Key)
+		}
+		assert.Contains(t, skillKeys, "skill-perception")
+		assert.Contains(t, skillKeys, "skill-investigation")
+		assert.NotContains(t, skillKeys, "skill-acrobatics") // Old skill should be gone
+		assert.NotContains(t, skillKeys, "skill-stealth")    // Old skill should be gone
+	})
+}

--- a/internal/services/character/rogue_creation_integration_test.go
+++ b/internal/services/character/rogue_creation_integration_test.go
@@ -1,0 +1,251 @@
+package character_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/clients/dnd5e"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/repositories/characters"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/services/character"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRogueCharacterCreationFlow tests the complete character creation flow for a Rogue
+// This is an integration test that uses the real D&D 5e API
+func TestRogueCharacterCreationFlow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// Use in-memory repository for testing
+	repo := characters.NewInMemoryRepository()
+
+	// Use real D&D 5e API client
+	client, err := dnd5e.New(&dnd5e.Config{
+		HttpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	})
+	require.NoError(t, err)
+
+	// Create service
+	service := character.NewService(&character.ServiceConfig{
+		DNDClient:  client,
+		Repository: repo,
+	})
+
+	// Test data
+	userID := "test-user-123"
+	realmID := "test-realm-456"
+
+	t.Run("Complete Rogue Creation Flow", func(t *testing.T) {
+		// Step 1: Create draft character
+		draft, err := service.GetOrCreateDraftCharacter(ctx, userID, realmID)
+		require.NoError(t, err)
+		require.NotNil(t, draft)
+		assert.Equal(t, entities.CharacterStatusDraft, draft.Status)
+
+		// Step 2: Select Human race
+		humanRace, err := service.GetRace(ctx, "human")
+		require.NoError(t, err)
+		assert.Equal(t, "Human", humanRace.Name)
+
+		raceKey := "human"
+		_, err = service.UpdateDraftCharacter(ctx, draft.ID, &character.UpdateDraftInput{
+			RaceKey: &raceKey,
+		})
+		require.NoError(t, err)
+
+		// Step 3: Select Rogue class
+		rogueClass, err := service.GetClass(ctx, "rogue")
+		require.NoError(t, err)
+		assert.Equal(t, "Rogue", rogueClass.Name)
+
+		classKey := "rogue"
+		_, err = service.UpdateDraftCharacter(ctx, draft.ID, &character.UpdateDraftInput{
+			ClassKey: &classKey,
+		})
+		require.NoError(t, err)
+
+		// Step 4: Assign ability scores
+		abilityScores := map[string]int{
+			"STR": 10,
+			"DEX": 15,
+			"CON": 13,
+			"INT": 12,
+			"WIS": 14,
+			"CHA": 8,
+		}
+		_, err = service.UpdateDraftCharacter(ctx, draft.ID, &character.UpdateDraftInput{
+			AbilityScores: abilityScores,
+		})
+		require.NoError(t, err)
+
+		// Step 5: Get proficiency choices
+		choices, err := service.ResolveChoices(ctx, &character.ResolveChoicesInput{
+			RaceKey:  "human",
+			ClassKey: "rogue",
+		})
+		require.NoError(t, err)
+
+		// Verify Rogue has proficiency choices
+		assert.Greater(t, len(choices.ProficiencyChoices), 0, "Rogue should have proficiency choices")
+
+		// Find the skill proficiency choice
+		var skillChoice *character.SimplifiedChoice
+		for _, choice := range choices.ProficiencyChoices {
+			// Check for skill proficiency choice (usually the first one for Rogue)
+			if strings.Contains(strings.ToLower(choice.Name), "skill") || choice.Choose == 4 {
+				skillChoice = &choice
+				break
+			}
+		}
+		require.NotNil(t, skillChoice, "Should have a skill proficiency choice")
+		assert.Equal(t, 4, skillChoice.Choose, "Rogue should choose 4 skills")
+		assert.GreaterOrEqual(t, len(skillChoice.Options), 11, "Should have at least 11 skill options")
+
+		// Step 6: Select proficiencies
+		selectedProficiencies := []string{
+			"skill-acrobatics",
+			"skill-perception",
+			"skill-stealth",
+			"skill-persuasion",
+		}
+		_, err = service.UpdateDraftCharacter(ctx, draft.ID, &character.UpdateDraftInput{
+			Proficiencies: selectedProficiencies,
+		})
+		require.NoError(t, err)
+
+		// Step 7: Verify equipment choices are available
+		// Re-fetch choices after proficiency selection
+		choices, err = service.ResolveChoices(ctx, &character.ResolveChoicesInput{
+			RaceKey:  "human",
+			ClassKey: "rogue",
+		})
+		require.NoError(t, err)
+
+		// Verify Rogue has equipment choices
+		assert.Greater(t, len(choices.EquipmentChoices), 0, "Rogue should have equipment choices")
+
+		// Log the equipment choices for debugging
+		t.Logf("Rogue equipment choices:")
+		for i, choice := range choices.EquipmentChoices {
+			t.Logf("  Choice %d: %s (choose %d from %d options)",
+				i, choice.Name, choice.Choose, len(choice.Options))
+		}
+
+		// Step 8: Finalize character with a name
+		name := "Shadowblade"
+		finalChar, err := service.UpdateDraftCharacter(ctx, draft.ID, &character.UpdateDraftInput{
+			Name: &name,
+		})
+		require.NoError(t, err)
+
+		// Verify final character state
+		assert.Equal(t, "Shadowblade", finalChar.Name)
+		assert.Equal(t, "human", finalChar.Race.Key)
+		assert.Equal(t, "rogue", finalChar.Class.Key)
+
+		// Verify proficiencies were saved
+		var profKeys []string
+		for _, profList := range finalChar.Proficiencies {
+			for _, prof := range profList {
+				profKeys = append(profKeys, prof.Key)
+			}
+		}
+		assert.Contains(t, profKeys, "skill-acrobatics")
+		assert.Contains(t, profKeys, "skill-perception")
+		assert.Contains(t, profKeys, "skill-stealth")
+		assert.Contains(t, profKeys, "skill-persuasion")
+
+		// Verify ability scores
+		assert.Equal(t, 10, finalChar.Attributes[entities.AttributeStrength].Score)
+		assert.Equal(t, 15, finalChar.Attributes[entities.AttributeDexterity].Score)
+		assert.Equal(t, 13, finalChar.Attributes[entities.AttributeConstitution].Score)
+		assert.Equal(t, 12, finalChar.Attributes[entities.AttributeIntelligence].Score)
+		assert.Equal(t, 14, finalChar.Attributes[entities.AttributeWisdom].Score)
+		assert.Equal(t, 8, finalChar.Attributes[entities.AttributeCharisma].Score)
+	})
+}
+
+// TestRogueProficiencyTransitionBug specifically tests the issue where
+// proficiency selection doesn't continue to equipment
+func TestRogueProficiencyTransitionBug(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	repo := characters.NewInMemoryRepository()
+	client, err := dnd5e.New(&dnd5e.Config{
+		HttpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	})
+	require.NoError(t, err)
+	service := character.NewService(&character.ServiceConfig{
+		DNDClient:  client,
+		Repository: repo,
+	})
+
+	// Create a draft character at the proficiency selection stage
+	draft, err := service.GetOrCreateDraftCharacter(ctx, "user123", "realm456")
+	require.NoError(t, err)
+
+	// Set up as Human Rogue with ability scores
+	raceKey := "human"
+	classKey := "rogue"
+	_, err = service.UpdateDraftCharacter(ctx, draft.ID, &character.UpdateDraftInput{
+		RaceKey:  &raceKey,
+		ClassKey: &classKey,
+		AbilityScores: map[string]int{
+			"STR": 10, "DEX": 15, "CON": 13,
+			"INT": 12, "WIS": 14, "CHA": 8,
+		},
+	})
+	require.NoError(t, err)
+
+	// Get initial choices
+	choicesBefore, err := service.ResolveChoices(ctx, &character.ResolveChoicesInput{
+		RaceKey:  "human",
+		ClassKey: "rogue",
+	})
+	require.NoError(t, err)
+
+	t.Logf("Choices before proficiency selection:")
+	t.Logf("  Proficiency choices: %d", len(choicesBefore.ProficiencyChoices))
+	t.Logf("  Equipment choices: %d", len(choicesBefore.EquipmentChoices))
+
+	// Select proficiencies
+	_, err = service.UpdateDraftCharacter(ctx, draft.ID, &character.UpdateDraftInput{
+		Proficiencies: []string{
+			"skill-acrobatics",
+			"skill-perception",
+			"skill-stealth",
+			"skill-persuasion",
+		},
+	})
+	require.NoError(t, err)
+
+	// Get choices after proficiency selection
+	choicesAfter, err := service.ResolveChoices(ctx, &character.ResolveChoicesInput{
+		RaceKey:  "human",
+		ClassKey: "rogue",
+	})
+	require.NoError(t, err)
+
+	t.Logf("Choices after proficiency selection:")
+	t.Logf("  Proficiency choices: %d", len(choicesAfter.ProficiencyChoices))
+	t.Logf("  Equipment choices: %d", len(choicesAfter.EquipmentChoices))
+
+	// Verify equipment choices are still available
+	assert.Greater(t, len(choicesAfter.EquipmentChoices), 0,
+		"Equipment choices should be available after proficiency selection")
+}


### PR DESCRIPTION
Fixes #73

## Problem
When creating a character (particularly rogues with 4 skill choices), proficiencies were accumulating infinitely instead of being replaced when users changed their selections. This happened because:

1. The handler was concatenating existing proficiencies with new selections
2. The service layer was adding all proficiencies without clearing previous selections
3. There was no distinction between base proficiencies (from race/class) and chosen proficiencies

## Solution
This PR implements a three-part fix:

1. **Added duplicate checking to `AddProficiency()`** - Prevents adding the same proficiency multiple times
2. **Added `SetProficiencies()` method** - Replaces all proficiencies of a given type
3. **Updated service layer logic** - Now uses `SetProficiencies` for skill proficiencies while preserving base proficiencies from race/class

## Testing
- Added unit tests for the new `SetProficiencies` method
- Added service layer test to verify proper proficiency replacement
- Added comprehensive integration test simulating the full bug scenario
- All existing tests continue to pass

## Behavior Changes
- Skill proficiencies are now replaced when updated (not accumulated)
- Other proficiency types (armor, weapons, saving throws) continue to accumulate as before
- Base proficiencies from race/class are always preserved