### PR TITLE
Fix: Get My Actions button for personalized combat UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,6 +379,41 @@ The interactive character sheet aims to provide a rich, real-time D&D experience
 - Real-time character sheet updates via WebSocket
 - Advanced visualizations (3D dice, battle maps)
 
+### Session Summary - November 16, 2024
+
+**Issue #98: Get My Actions Button Implementation** ✅
+- **Branch**: `fix-98-get-my-actions`
+- **Status**: Implementation complete, ready for PR
+- **Problem Solved**: Multiplayer combat had shared button states causing "not your turn" errors
+- **Solution**: Added ephemeral "Get My Actions" button for personalized combat interfaces
+
+#### What Was Implemented:
+1. **New handleMyActions method** in combat handler
+   - Sends private ephemeral response to each player
+   - Shows personalized action buttons based on turn state
+   - Displays player's HP, AC, and current turn status
+
+2. **UI Updates**:
+   - Added "Get My Actions" button to all combat displays
+   - Button uses green success style with 🎯 emoji
+   - Integrated into enter_room, combat handler, and embed builders
+
+3. **Code Quality**:
+   - Fixed 4 errcheck linting issues
+   - Fixed parameter shadowing (max → maxHP)
+   - Added proper error logging for monster turn processing
+
+#### Next Steps:
+1. Create PR for issue #98
+2. Test multiplayer combat with new personalized actions
+3. Monitor for the duplicate combat UI issue (added TODO comment)
+4. Consider adding more action types (potions, spells, abilities)
+
+#### Known Issues to Monitor:
+- **Duplicate Combat UI**: First player sometimes gets old style message, needs to enter room again
+- **Turn Order Sync**: May need additional testing with 3+ players
+- **Button Limits**: Discord's 25-button limit may affect future action additions
+
 ### Contact
 - GitHub Issues: https://github.com/KirkDiggler/dnd-bot-discord/issues
 - GitHub Project: https://github.com/users/KirkDiggler/projects/6

--- a/internal/handlers/discord/combat/embed_builders.go
+++ b/internal/handlers/discord/combat/embed_builders.go
@@ -272,17 +272,10 @@ func buildCombatComponents(encounterID string, result *encounter.ExecuteAttackRe
 		}
 	}
 
-	// Normal combat buttons
+	// Normal combat buttons - no Attack button on shared messages
 	return []discordgo.MessageComponent{
 		discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
-				discordgo.Button{
-					Label:    "Attack Again",
-					Style:    discordgo.DangerButton,
-					CustomID: fmt.Sprintf("combat:attack:%s", encounterID),
-					Emoji:    &discordgo.ComponentEmoji{Name: "⚔️"},
-					Disabled: !result.IsPlayerTurn,
-				},
 				discordgo.Button{
 					Label:    "Next Turn",
 					Style:    discordgo.PrimaryButton,
@@ -295,16 +288,16 @@ func buildCombatComponents(encounterID string, result *encounter.ExecuteAttackRe
 					CustomID: fmt.Sprintf("combat:my_actions:%s", encounterID),
 					Emoji:    &discordgo.ComponentEmoji{Name: "🎯"},
 				},
-			},
-		},
-		discordgo.ActionsRow{
-			Components: []discordgo.MessageComponent{
 				discordgo.Button{
 					Label:    "View Status",
 					Style:    discordgo.SecondaryButton,
 					CustomID: fmt.Sprintf("combat:view:%s", encounterID),
 					Emoji:    &discordgo.ComponentEmoji{Name: "📊"},
 				},
+			},
+		},
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
 				discordgo.Button{
 					Label:    "History",
 					Style:    discordgo.SecondaryButton,

--- a/internal/handlers/discord/combat/embed_builders.go
+++ b/internal/handlers/discord/combat/embed_builders.go
@@ -290,6 +290,16 @@ func buildCombatComponents(encounterID string, result *encounter.ExecuteAttackRe
 					Emoji:    &discordgo.ComponentEmoji{Name: "➡️"},
 				},
 				discordgo.Button{
+					Label:    "Get My Actions",
+					Style:    discordgo.SuccessButton,
+					CustomID: fmt.Sprintf("combat:my_actions:%s", encounterID),
+					Emoji:    &discordgo.ComponentEmoji{Name: "🎯"},
+				},
+			},
+		},
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.Button{
 					Label:    "View Status",
 					Style:    discordgo.SecondaryButton,
 					CustomID: fmt.Sprintf("combat:view:%s", encounterID),
@@ -307,11 +317,11 @@ func buildCombatComponents(encounterID string, result *encounter.ExecuteAttackRe
 }
 
 // getHPBar returns an emoji HP indicator
-func getHPBar(current, max int) string {
-	if max == 0 {
+func getHPBar(current, maxHP int) string {
+	if maxHP == 0 {
 		return "💀"
 	}
-	percent := float64(current) / float64(max)
+	percent := float64(current) / float64(maxHP)
 	if percent > 0.5 {
 		return "🟢"
 	} else if percent > 0.25 {

--- a/internal/handlers/discord/combat/handler.go
+++ b/internal/handlers/discord/combat/handler.go
@@ -93,7 +93,7 @@ func (h *Handler) handleAttack(s *discordgo.Session, i *discordgo.InteractionCre
 		if target.ID == attacker.ID || !target.IsActive || target.CurrentHP <= 0 {
 			continue
 		}
-		
+
 		// Players cannot attack other players
 		if attacker.Type == entities.CombatantTypePlayer && target.Type == entities.CombatantTypePlayer {
 			continue
@@ -844,7 +844,7 @@ func (h *Handler) handleAttackFromEphemeral(s *discordgo.Session, i *discordgo.I
 		if target.ID == attacker.ID || !target.IsActive || target.CurrentHP <= 0 {
 			continue
 		}
-		
+
 		// Players cannot attack other players
 		if attacker.Type == entities.CombatantTypePlayer && target.Type == entities.CombatantTypePlayer {
 			continue

--- a/internal/handlers/discord/combat/handler.go
+++ b/internal/handlers/discord/combat/handler.go
@@ -93,6 +93,11 @@ func (h *Handler) handleAttack(s *discordgo.Session, i *discordgo.InteractionCre
 		if target.ID == attacker.ID || !target.IsActive || target.CurrentHP <= 0 {
 			continue
 		}
+		
+		// Players cannot attack other players
+		if attacker.Type == entities.CombatantTypePlayer && target.Type == entities.CombatantTypePlayer {
+			continue
+		}
 
 		emoji := "🧑"
 		if target.Type == entities.CombatantTypeMonster {
@@ -837,6 +842,11 @@ func (h *Handler) handleAttackFromEphemeral(s *discordgo.Session, i *discordgo.I
 	var buttons []discordgo.MessageComponent
 	for _, target := range enc.Combatants {
 		if target.ID == attacker.ID || !target.IsActive || target.CurrentHP <= 0 {
+			continue
+		}
+		
+		// Players cannot attack other players
+		if attacker.Type == entities.CombatantTypePlayer && target.Type == entities.CombatantTypePlayer {
 			continue
 		}
 

--- a/internal/handlers/discord/combat/handler.go
+++ b/internal/handlers/discord/combat/handler.go
@@ -52,12 +52,12 @@ func (h *Handler) handleAttack(s *discordgo.Session, i *discordgo.InteractionCre
 	// Check if this is from an ephemeral message (like My Actions)
 	// If so, we need to send a new ephemeral response instead of updating
 	isFromEphemeral := i.Message != nil && i.Message.Flags&discordgo.MessageFlagsEphemeral != 0
-	
+
 	if isFromEphemeral {
 		// For ephemeral sources, send a new ephemeral response with target selection
 		return h.handleAttackFromEphemeral(s, i, encounterID)
 	}
-	
+
 	// Defer response for processing (for shared messages)
 	if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredMessageUpdate,
@@ -143,7 +143,7 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 
 	// Check if this interaction came from an ephemeral message
 	isFromEphemeral := i.Message != nil && i.Message.Flags&discordgo.MessageFlagsEphemeral != 0
-	
+
 	if !isFromEphemeral {
 		// Only defer for non-ephemeral messages
 		if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -193,12 +193,12 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 
 	// Build components based on state
 	components := buildCombatComponents(encounterID, result)
-	
+
 	if isFromEphemeral {
 		// For ephemeral interactions, we need to:
 		// 1. Respond to the ephemeral interaction
 		// 2. Update the main shared combat message
-		
+
 		// Show attack result with option to get new action controller
 		attackSummary := "Attack executed!"
 		if result.PlayerAttack != nil {
@@ -212,7 +212,7 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 				attackSummary = "❌ MISS! Your attack missed!"
 			}
 		}
-		
+
 		resultEmbed := &discordgo.MessageEmbed{
 			Title:       "⚔️ Attack Result",
 			Description: attackSummary,
@@ -221,7 +221,7 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 				Text: "Click below to return to your action controller",
 			},
 		}
-		
+
 		// Simple button to get back to action controller
 		resultComponents := []discordgo.MessageComponent{
 			discordgo.ActionsRow{
@@ -235,7 +235,7 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 				},
 			},
 		}
-		
+
 		// Update the ephemeral message with the result
 		err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -248,7 +248,7 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 		if err != nil {
 			log.Printf("Failed to update ephemeral message with result: %v", err)
 		}
-		
+
 		// Now update the main shared combat message
 		if enc.MessageID != "" && enc.ChannelID != "" {
 			log.Printf("Updating main combat message: MessageID=%s, ChannelID=%s", enc.MessageID, enc.ChannelID)
@@ -266,7 +266,7 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 		}
 		return err
 	}
-	
+
 	// For non-ephemeral interactions, update the message directly
 	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Embeds:     &[]*discordgo.MessageEmbed{embed},
@@ -279,7 +279,7 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 func (h *Handler) handleNextTurn(s *discordgo.Session, i *discordgo.InteractionCreate, encounterID string) error {
 	// Check if this is from an ephemeral message
 	isFromEphemeral := i.Message != nil && i.Message.Flags&discordgo.MessageFlagsEphemeral != 0
-	
+
 	if !isFromEphemeral {
 		// Defer response for processing (for shared messages)
 		if err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -388,7 +388,7 @@ func (h *Handler) handleNextTurn(s *discordgo.Session, i *discordgo.InteractionC
 		if err != nil {
 			log.Printf("Failed to respond to ephemeral interaction: %v", err)
 		}
-		
+
 		// Update the main shared combat message
 		if enc.MessageID != "" && enc.ChannelID != "" {
 			log.Printf("Updating main combat message from next turn: MessageID=%s, ChannelID=%s", enc.MessageID, enc.ChannelID)
@@ -406,7 +406,7 @@ func (h *Handler) handleNextTurn(s *discordgo.Session, i *discordgo.InteractionC
 		}
 		return err
 	}
-	
+
 	// For non-ephemeral, update the original message
 	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Embeds:     &[]*discordgo.MessageEmbed{embed},
@@ -738,7 +738,7 @@ func (h *Handler) handleMyActions(s *discordgo.Session, i *discordgo.Interaction
 			},
 		},
 	}
-	
+
 	// Update description based on turn status
 	if !isMyTurn && enc.Status == entities.EncounterStatusActive {
 		if current := enc.GetCurrentCombatant(); current != nil {
@@ -759,7 +759,7 @@ func (h *Handler) handleMyActions(s *discordgo.Session, i *discordgo.Interaction
 
 	// Check if this is being called from an ephemeral message (like "Back to Actions")
 	isFromEphemeral := i.Message != nil && i.Message.Flags&discordgo.MessageFlagsEphemeral != 0
-	
+
 	if isFromEphemeral {
 		// Update the existing ephemeral message
 		return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -770,7 +770,7 @@ func (h *Handler) handleMyActions(s *discordgo.Session, i *discordgo.Interaction
 			},
 		})
 	}
-	
+
 	// Create new ephemeral message (when called from shared message buttons)
 	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -802,7 +802,7 @@ func (h *Handler) handleAttackFromEphemeral(s *discordgo.Session, i *discordgo.I
 	if attacker == nil || !attacker.IsActive {
 		return respondError(s, i, "No active character found", nil)
 	}
-	
+
 	// Check if it's actually this player's turn
 	current := enc.GetCurrentCombatant()
 	if current == nil || current.ID != attacker.ID {
@@ -815,7 +815,7 @@ func (h *Handler) handleAttackFromEphemeral(s *discordgo.Session, i *discordgo.I
 				Text: "Wait for your turn to attack",
 			},
 		}
-		
+
 		components := []discordgo.MessageComponent{
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
@@ -828,7 +828,7 @@ func (h *Handler) handleAttackFromEphemeral(s *discordgo.Session, i *discordgo.I
 				},
 			},
 		}
-		
+
 		return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
 			Data: &discordgo.InteractionResponseData{

--- a/internal/handlers/discord/combat/helpers.go
+++ b/internal/handlers/discord/combat/helpers.go
@@ -13,6 +13,11 @@ func parseCustomID(customID string) []string {
 	return strings.Split(customID, ":")
 }
 
+// isEphemeralInteraction checks if an interaction originated from an ephemeral message
+func isEphemeralInteraction(i *discordgo.InteractionCreate) bool {
+	return i.Message != nil && i.Message.Flags&discordgo.MessageFlagsEphemeral != 0
+}
+
 // respondError sends an error response
 func respondError(s *discordgo.Session, i *discordgo.InteractionCreate, message string, err error) error {
 	content := fmt.Sprintf("❌ %s", message)

--- a/internal/handlers/discord/dnd/dungeon/enter_room.go
+++ b/internal/handlers/discord/dnd/dungeon/enter_room.go
@@ -387,6 +387,16 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 					Emoji:    &discordgo.ComponentEmoji{Name: "➡️"},
 				},
 				discordgo.Button{
+					Label:    "Get My Actions",
+					Style:    discordgo.SuccessButton,
+					CustomID: fmt.Sprintf("combat:my_actions:%s", enc.ID),
+					Emoji:    &discordgo.ComponentEmoji{Name: "🎯"},
+				},
+			},
+		},
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.Button{
 					Label:    "Status",
 					Style:    discordgo.SecondaryButton,
 					CustomID: fmt.Sprintf("combat:view:%s", enc.ID),
@@ -401,6 +411,11 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 			},
 		},
 	}
+
+	// TODO: Address duplicate combat UI issue - when 2 players are in a dungeon,
+	// the first player gets the old style message and needs to enter again to get
+	// the newer shared message format. This may be due to multiple handlers responding
+	// to the same interaction.
 
 	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Embeds:     &[]*discordgo.MessageEmbed{embed},


### PR DESCRIPTION
Fixes #98

## Summary
Implemented the "Get My Actions" button to provide personalized ephemeral combat controllers for each player, solving the multiplayer combat issue where shared buttons were causing "not your turn" errors.

## Changes
- Added `handleMyActions` method that creates ephemeral action controllers
- Removed Attack buttons from all shared combat messages
- Separated shared status messages from personal action controllers
- Added turn validation with friendly error messages
- Fixed ephemeral message stacking by updating instead of creating new messages
- Added "Back to Actions" flow after attack execution

## Test Plan
- [ ] Test single player combat - verify personal action controller works
- [ ] Test multiplayer combat - verify each player gets their own controller
- [ ] Test turn validation - clicking attack when not your turn shows friendly message
- [ ] Test combat flow - attack → target → result → back to actions
- [ ] Verify shared message has no Attack buttons
- [ ] Check logs for MessageID warnings (known issue for follow-up)

## Known Issues
- Shared combat message doesn't update from ephemeral actions (MessageID not stored) - will be addressed in separate issue

🤖 Generated with [Claude Code](https://claude.ai/code)