### PR TITLE
Update shared combat message when actions occur

### DIFF
--- a/internal/handlers/discord/combat/handler.go
+++ b/internal/handlers/discord/combat/handler.go
@@ -251,21 +251,8 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 		}
 
 		// Now update the main shared combat message
-		if enc.MessageID != "" && enc.ChannelID != "" {
-			log.Printf("Updating main combat message: MessageID=%s, ChannelID=%s", enc.MessageID, enc.ChannelID)
-			_, err = s.ChannelMessageEditComplex(&discordgo.MessageEdit{
-				ID:         enc.MessageID,
-				Channel:    enc.ChannelID,
-				Embeds:     &[]*discordgo.MessageEmbed{embed},
-				Components: &components,
-			})
-			if err != nil {
-				log.Printf("Failed to update main combat message: %v", err)
-			}
-		} else {
-			log.Printf("WARNING: Cannot update main combat message - MessageID=%s, ChannelID=%s", enc.MessageID, enc.ChannelID)
-		}
-		return err
+		updateSharedCombatMessage(s, encounterID, enc.MessageID, enc.ChannelID, embed, components)
+		return nil
 	}
 
 	// For non-ephemeral interactions, update the message directly
@@ -273,6 +260,12 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 		Embeds:     &[]*discordgo.MessageEmbed{embed},
 		Components: &components,
 	})
+
+	// Also update the shared message if this wasn't the shared message itself
+	if i.Message == nil || i.Message.ID != enc.MessageID {
+		updateSharedCombatMessage(s, encounterID, enc.MessageID, enc.ChannelID, embed, components)
+	}
+
 	return err
 }
 
@@ -392,21 +385,8 @@ func (h *Handler) handleNextTurn(s *discordgo.Session, i *discordgo.InteractionC
 		}
 
 		// Update the main shared combat message
-		if enc.MessageID != "" && enc.ChannelID != "" {
-			log.Printf("Updating main combat message from next turn: MessageID=%s, ChannelID=%s", enc.MessageID, enc.ChannelID)
-			_, err = s.ChannelMessageEditComplex(&discordgo.MessageEdit{
-				ID:         enc.MessageID,
-				Channel:    enc.ChannelID,
-				Embeds:     &[]*discordgo.MessageEmbed{embed},
-				Components: &components,
-			})
-			if err != nil {
-				log.Printf("Failed to update main combat message: %v", err)
-			}
-		} else {
-			log.Printf("WARNING: Cannot update main combat message from next turn - MessageID=%s, ChannelID=%s", enc.MessageID, enc.ChannelID)
-		}
-		return err
+		updateSharedCombatMessage(s, encounterID, enc.MessageID, enc.ChannelID, embed, components)
+		return nil
 	}
 
 	// For non-ephemeral, update the original message
@@ -414,6 +394,12 @@ func (h *Handler) handleNextTurn(s *discordgo.Session, i *discordgo.InteractionC
 		Embeds:     &[]*discordgo.MessageEmbed{embed},
 		Components: &components,
 	})
+
+	// Also update the shared message if this wasn't the shared message itself
+	if i.Message == nil || i.Message.ID != enc.MessageID {
+		updateSharedCombatMessage(s, encounterID, enc.MessageID, enc.ChannelID, embed, components)
+	}
+
 	return err
 }
 

--- a/internal/handlers/discord/combat/helpers.go
+++ b/internal/handlers/discord/combat/helpers.go
@@ -48,3 +48,32 @@ func respondEditError(s *discordgo.Session, i *discordgo.InteractionCreate, mess
 	})
 	return editErr
 }
+
+// DiscordSession interface for Discord operations (for testing)
+type DiscordSession interface {
+	ChannelMessageEditComplex(edit *discordgo.MessageEdit, options ...discordgo.RequestOption) (*discordgo.Message, error)
+}
+
+// updateSharedCombatMessage updates the main shared combat message if MessageID is stored
+func updateSharedCombatMessage(s DiscordSession, encounterID, messageID, channelID string, embed *discordgo.MessageEmbed, components []discordgo.MessageComponent) error {
+	if messageID == "" || channelID == "" {
+		log.Printf("WARNING: Cannot update shared combat message - MessageID=%s, ChannelID=%s", messageID, channelID)
+		return nil // Not an error, just can't update
+	}
+
+	log.Printf("Updating shared combat message: EncounterID=%s, MessageID=%s, ChannelID=%s", encounterID, messageID, channelID)
+
+	_, err := s.ChannelMessageEditComplex(&discordgo.MessageEdit{
+		ID:         messageID,
+		Channel:    channelID,
+		Embeds:     &[]*discordgo.MessageEmbed{embed},
+		Components: &components,
+	})
+
+	if err != nil {
+		log.Printf("Failed to update shared combat message: %v", err)
+		// Don't return error - combat should continue even if message update fails
+	}
+
+	return nil
+}

--- a/internal/handlers/discord/combat/helpers_test.go
+++ b/internal/handlers/discord/combat/helpers_test.go
@@ -1,0 +1,85 @@
+package combat
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// TestUpdateSharedCombatMessage tests the updateSharedCombatMessage helper
+func TestUpdateSharedCombatMessage(t *testing.T) {
+	// Create a mock session that tracks calls
+	callCount := 0
+	var capturedEdit *discordgo.MessageEdit
+
+	mockSession := &mockSession{
+		channelMessageEditComplex: func(edit *discordgo.MessageEdit) (*discordgo.Message, error) {
+			callCount++
+			capturedEdit = edit
+			return &discordgo.Message{}, nil
+		},
+	}
+
+	embed := &discordgo.MessageEmbed{Title: "Test Combat"}
+	components := []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.Button{Label: "Test"},
+			},
+		},
+	}
+
+	// Test with valid MessageID and ChannelID
+	t.Run("ValidIDs", func(t *testing.T) {
+		callCount = 0
+		err := updateSharedCombatMessage(mockSession, "enc-123", "msg-456", "channel-789", embed, components)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if callCount != 1 {
+			t.Errorf("Expected 1 call, got %d", callCount)
+		}
+		if capturedEdit.ID != "msg-456" {
+			t.Errorf("Expected message ID msg-456, got %s", capturedEdit.ID)
+		}
+		if capturedEdit.Channel != "channel-789" {
+			t.Errorf("Expected channel ID channel-789, got %s", capturedEdit.Channel)
+		}
+	})
+
+	// Test with empty MessageID
+	t.Run("EmptyMessageID", func(t *testing.T) {
+		callCount = 0
+		err := updateSharedCombatMessage(mockSession, "enc-123", "", "channel-789", embed, components)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if callCount != 0 {
+			t.Errorf("Expected no calls with empty MessageID, got %d", callCount)
+		}
+	})
+
+	// Test with empty ChannelID
+	t.Run("EmptyChannelID", func(t *testing.T) {
+		callCount = 0
+		err := updateSharedCombatMessage(mockSession, "enc-123", "msg-456", "", embed, components)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if callCount != 0 {
+			t.Errorf("Expected no calls with empty ChannelID, got %d", callCount)
+		}
+	})
+}
+
+// mockSession is a minimal mock for testing
+type mockSession struct {
+	channelMessageEditComplex func(*discordgo.MessageEdit) (*discordgo.Message, error)
+}
+
+func (m *mockSession) ChannelMessageEditComplex(edit *discordgo.MessageEdit, options ...discordgo.RequestOption) (*discordgo.Message, error) {
+	if m.channelMessageEditComplex != nil {
+		return m.channelMessageEditComplex(edit)
+	}
+	return nil, nil
+}


### PR DESCRIPTION
## Summary
Fixes #103

This PR implements real-time updates to the shared combat message when actions occur during combat. Now all players see combat updates without needing to click the History button.

## Changes
- Add `updateSharedCombatMessage` helper function to centralize message update logic
- Update shared message after attacks from both ephemeral and non-ephemeral sources
- Update shared message after turn advances
- Add `DiscordSession` interface to make the code more testable
- Add tests for the shared message update helper
- Handle cases where MessageID or ChannelID are empty (graceful degradation)

## How it works
1. When combat starts, MessageID is stored (from PR #102)
2. After any combat action (attack, turn advance), the shared message is updated
3. Updates are non-blocking - combat continues even if message update fails
4. Prevents duplicate updates when action originates from the shared message itself

## Testing
- Added unit tests for `updateSharedCombatMessage` helper
- Tests verify correct behavior with valid IDs, empty MessageID, and empty ChannelID
- Manual testing needed to verify Discord message updates work end-to-end

## Next Steps
- Monitor for rate limit issues (Discord allows 5 edits per 5 seconds per message)
- Consider batching rapid updates if needed
- Add player join/character selection updates to shared message