### PR TITLE
Fix: Combat gets stuck on dead monster's turn

### DIFF
--- a/internal/entities/encounter.go
+++ b/internal/entities/encounter.go
@@ -130,6 +130,17 @@ func (e *Encounter) Start() bool {
 	e.StartedAt = &now
 	e.Round = 1
 	e.Turn = 0
+
+	// Skip dead combatants at the start
+	for e.Turn < len(e.TurnOrder) {
+		if combatant, exists := e.Combatants[e.TurnOrder[e.Turn]]; exists && combatant.IsActive && combatant.CurrentHP > 0 {
+			// Found an active, alive combatant
+			break
+		}
+		// Skip this dead/inactive combatant
+		e.Turn++
+	}
+
 	return true
 }
 
@@ -146,7 +157,18 @@ func (e *Encounter) NextTurn() {
 		}
 	}
 
+	// Advance turn
 	e.Turn++
+
+	// Skip dead combatants
+	for e.Turn < len(e.TurnOrder) {
+		if combatant, exists := e.Combatants[e.TurnOrder[e.Turn]]; exists && combatant.IsActive && combatant.CurrentHP > 0 {
+			// Found an active, alive combatant
+			break
+		}
+		// Skip this dead/inactive combatant
+		e.Turn++
+	}
 
 	// Check if round is complete
 	if e.Turn >= len(e.TurnOrder) {
@@ -162,6 +184,16 @@ func (e *Encounter) NextRound() {
 	// Reset all combatants' HasActed flag
 	for _, combatant := range e.Combatants {
 		combatant.HasActed = false
+	}
+
+	// Skip dead combatants at the start of the round
+	for e.Turn < len(e.TurnOrder) {
+		if combatant, exists := e.Combatants[e.TurnOrder[e.Turn]]; exists && combatant.IsActive && combatant.CurrentHP > 0 {
+			// Found an active, alive combatant
+			break
+		}
+		// Skip this dead/inactive combatant
+		e.Turn++
 	}
 }
 

--- a/internal/entities/encounter_test.go
+++ b/internal/entities/encounter_test.go
@@ -2,6 +2,7 @@ package entities_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
 	"github.com/stretchr/testify/assert"
@@ -122,4 +123,179 @@ func TestCombatLog(t *testing.T) {
 		// First 5 entries should have been removed
 		assert.Equal(t, "Round 0: Test action", encounter.CombatLog[0])
 	})
+}
+
+func TestEncounter_NextTurn_SkipsDeadCombatants(t *testing.T) {
+	// Create an encounter with some combatants
+	enc := &entities.Encounter{
+		ID:         "test-encounter",
+		Status:     entities.EncounterStatusActive,
+		Round:      1,
+		Turn:       0,
+		Combatants: make(map[string]*entities.Combatant),
+		TurnOrder:  []string{"c1", "c2", "c3", "c4"},
+		StartedAt:  &time.Time{},
+	}
+
+	// Add combatants - c2 and c3 are dead
+	enc.Combatants["c1"] = &entities.Combatant{
+		ID:        "c1",
+		Name:      "Fighter",
+		IsActive:  true,
+		CurrentHP: 10,
+		MaxHP:     10,
+	}
+	enc.Combatants["c2"] = &entities.Combatant{
+		ID:        "c2",
+		Name:      "Dead Goblin",
+		IsActive:  true,
+		CurrentHP: 0, // Dead
+		MaxHP:     5,
+	}
+	enc.Combatants["c3"] = &entities.Combatant{
+		ID:        "c3",
+		Name:      "Inactive Orc",
+		IsActive:  false, // Inactive
+		CurrentHP: 10,
+		MaxHP:     10,
+	}
+	enc.Combatants["c4"] = &entities.Combatant{
+		ID:        "c4",
+		Name:      "Wizard",
+		IsActive:  true,
+		CurrentHP: 8,
+		MaxHP:     8,
+	}
+
+	// Start at turn 0 (Fighter)
+	current := enc.GetCurrentCombatant()
+	assert.Equal(t, "c1", current.ID)
+
+	// Advance turn - should skip dead goblin and inactive orc, land on wizard
+	enc.NextTurn()
+	current = enc.GetCurrentCombatant()
+	assert.Equal(t, "c4", current.ID)
+
+	// Advance turn again - should go to next round and back to fighter
+	enc.NextTurn()
+	assert.Equal(t, 2, enc.Round)
+	current = enc.GetCurrentCombatant()
+	assert.Equal(t, "c1", current.ID)
+}
+
+func TestEncounter_NextRound_SkipsDeadCombatants(t *testing.T) {
+	// Create an encounter where the first combatant is dead
+	enc := &entities.Encounter{
+		ID:         "test-encounter",
+		Status:     entities.EncounterStatusActive,
+		Round:      1,
+		Turn:       2,
+		Combatants: make(map[string]*entities.Combatant),
+		TurnOrder:  []string{"c1", "c2", "c3"},
+		StartedAt:  &time.Time{},
+	}
+
+	// c1 is dead, c2 is alive, c3 is alive
+	enc.Combatants["c1"] = &entities.Combatant{
+		ID:        "c1",
+		Name:      "Dead Fighter",
+		IsActive:  true,
+		CurrentHP: 0, // Dead
+		MaxHP:     10,
+	}
+	enc.Combatants["c2"] = &entities.Combatant{
+		ID:        "c2",
+		Name:      "Cleric",
+		IsActive:  true,
+		CurrentHP: 12,
+		MaxHP:     12,
+	}
+	enc.Combatants["c3"] = &entities.Combatant{
+		ID:        "c3",
+		Name:      "Rogue",
+		IsActive:  true,
+		CurrentHP: 8,
+		MaxHP:     8,
+	}
+
+	// Start new round
+	enc.NextRound()
+
+	// Should be round 2, turn should skip dead fighter and be on cleric
+	assert.Equal(t, 2, enc.Round)
+	assert.Equal(t, 1, enc.Turn)
+	current := enc.GetCurrentCombatant()
+	assert.Equal(t, "c2", current.ID)
+}
+
+func TestEncounter_Start_SkipsDeadCombatants(t *testing.T) {
+	// Create an encounter in rolling status
+	enc := &entities.Encounter{
+		ID:         "test-encounter",
+		Status:     entities.EncounterStatusRolling,
+		Combatants: make(map[string]*entities.Combatant),
+		TurnOrder:  []string{"c1", "c2"},
+	}
+
+	// First combatant is dead
+	enc.Combatants["c1"] = &entities.Combatant{
+		ID:        "c1",
+		Name:      "Dead Zombie",
+		IsActive:  true,
+		CurrentHP: 0, // Dead
+		MaxHP:     10,
+	}
+	enc.Combatants["c2"] = &entities.Combatant{
+		ID:        "c2",
+		Name:      "Living Paladin",
+		IsActive:  true,
+		CurrentHP: 15,
+		MaxHP:     15,
+	}
+
+	// Start the encounter
+	assert.True(t, enc.Start())
+
+	// Should skip dead zombie and start with paladin
+	assert.Equal(t, 1, enc.Turn)
+	current := enc.GetCurrentCombatant()
+	assert.Equal(t, "c2", current.ID)
+}
+
+func TestEncounter_AllCombatantsDead(t *testing.T) {
+	// Edge case: all combatants are dead
+	enc := &entities.Encounter{
+		ID:         "test-encounter",
+		Status:     entities.EncounterStatusActive,
+		Round:      1,
+		Turn:       0,
+		Combatants: make(map[string]*entities.Combatant),
+		TurnOrder:  []string{"c1", "c2"},
+		StartedAt:  &time.Time{},
+	}
+
+	// Both combatants are dead
+	enc.Combatants["c1"] = &entities.Combatant{
+		ID:        "c1",
+		Name:      "Dead Fighter",
+		IsActive:  true,
+		CurrentHP: 0,
+		MaxHP:     10,
+	}
+	enc.Combatants["c2"] = &entities.Combatant{
+		ID:        "c2",
+		Name:      "Dead Goblin",
+		IsActive:  true,
+		CurrentHP: 0,
+		MaxHP:     5,
+	}
+
+	// Advance turn - should handle gracefully
+	enc.NextTurn()
+
+	// Turn should advance past all dead combatants
+	assert.GreaterOrEqual(t, enc.Turn, len(enc.TurnOrder))
+
+	// Should have advanced to next round
+	assert.Equal(t, 2, enc.Round)
 }


### PR DESCRIPTION
Fixes #105

## Problem
Combat would get stuck when it became a dead monster's turn, preventing the game from progressing.

## Solution
Modified the turn advancement logic to automatically skip dead or inactive combatants:
- NextTurn() now skips dead/inactive combatants when advancing
- NextRound() skips dead combatants at the start of a new round
- Start() skips dead combatants when combat begins

## Testing
Added comprehensive unit tests covering:
- Skipping dead combatants during normal turn progression
- Skipping dead combatants at round start
- Skipping dead combatants when combat begins
- Edge case handling when all combatants are dead

All new tests pass successfully.