### PR TITLE
Fix: Improve combat message clarity with visual indicators and initiative display

### DIFF
--- a/docs/combat-display-demo.md
+++ b/docs/combat-display-demo.md
@@ -1,0 +1,64 @@
+# Combat Display Enhancement Demo
+
+## New Initiative Field Display
+
+The new display separates players and monsters into distinct embed fields:
+
+### 🛡️ Party Members
+▶ `18` 💚 **Grunk**
+├─ 🟢🟢🟢🟢🟢🟢🟢🟢🟡⬜ HP: 45/50 | AC: 16
+└─ *Barbarian*
+
+  `10` 💚 **Thorin**
+├─ 🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢 HP: 40/40 | AC: 18
+└─ *Fighter*
+
+### ⚔️ Enemies
+  `15` 🧡 **Goblin**
+├─ 🔴🔴🔴⬜⬜⬜⬜⬜⬜⬜ HP: 3/12 | AC: 13
+
+
+## Features Demonstrated
+
+1. **Visual HP Indicators**:
+   - 💚 = Healthy (>75% HP)
+   - 💛 = Good (50-75% HP)
+   - 🧡 = Hurt (25-50% HP)
+   - ❤️ = Critical (<25% HP)
+   - 💀 = Dead (0 HP)
+
+2. **HP Bars**: Visual representation using emoji squares showing exact health percentage
+
+3. **Turn Indicator**: ▶ shows whose turn it is currently
+
+4. **Name Truncation**: Long names are truncated to 15 characters with "..."
+
+5. **Class Display**: Player characters show their class in italics below their stats
+
+## Alternative Compact Display
+
+Also implemented a CSS-styled compact view:
+
+```css
+[Initiative Order]
+─────────────────────────────────────────
+▶ [18] 👤 Grunk        HP[▰▰▰▰▰▰▰▱] AC:16
+  [15] 👹 Goblin       HP[▰▰▱▱▱▱▱▱] AC:13
+  [10] 👤 Thorin       HP[▰▰▰▰▰▰▰▰] AC:18
+```
+
+## Detailed Combatant View
+
+For individual combatant details:
+
+**💚 Grunk**
+📊 **Stats**
+**HP:** 45/50
+**AC:** 16
+**Initiative:** 18
+
+⚔️ **Class**
+Barbarian
+
+💚 **Health**
+🟩🟩🟩🟩🟩🟩🟩🟩🟩⬜

--- a/docs/combat-display-example.md
+++ b/docs/combat-display-example.md
@@ -1,0 +1,55 @@
+# Combat Display Example
+
+## Combat Status Embed
+
+**⚔️ Combat - Round 3**
+
+⚔️ **Round 3** | 🛡️ Players: 2 | 🐉 Monsters: 2
+🎯 **Grunk's turn**
+
+### 🎯 Initiative Order
+```
+Init │ Name              │ HP          │ AC
+─────┼───────────────────┼─────────────┼────
+▶ 18  │ 🪓 Grunk          │ ▰▰▰▰▰▰▰▱  45/50 │ 16
+  15  │ 🐉 Goblin         │ ▰▰▱▱▱▱▱▱   3/12 │ 13 ❗
+  12  │ 🐉 Orc            │ ▰▰▰▰▰▰▱▱  15/20 │ 14
+  10  │ ⚔️ Thorin         │ ▰▰▰▰▰▰▰▰  40/40 │ 18
+```
+
+### 📜 Recent Actions
+• ⚔️ **Grunk** → **Goblin** | d20:19+7=26 vs AC:13 | HIT 🩸 **12** [10]+2
+• ⚔️ **Goblin** → **Grunk** | d20:8+4=12 vs AC:16 | ❌ MISS
+• ⚔️ **Thorin** → **Orc** | d20:15+5=20 vs AC:14 | HIT 🩸 **8** [6]+2
+• ⚔️ **Orc** → **Thorin** | d20:12+4=16 vs AC:18 | ❌ MISS
+• ⚔️ **Grunk** → **Goblin** | d20:**20**+7=27 vs AC:13 | 💥 CRIT! 🩸 **24** [10,8]+4
+
+## What Each Part Means
+
+### Attack Roll Format
+`⚔️ **Attacker** → **Target** | d20:roll+bonus=total vs AC:armor | result`
+
+- **d20:19+7=26**: Shows the d20 roll (19), attack bonus (+7), and total (26)
+- **vs AC:13**: Shows what AC the attack is trying to beat
+- **HIT/MISS**: Clear result indicator
+- **🩸 12 [10]+2**: Total damage (12) with dice rolls [10] and bonus (+2)
+
+### Critical Hits
+- **d20:20**: Natural 20 shown in bold
+- **💥 CRIT!**: Clear critical indicator
+- Damage shows doubled dice: [10,8]+4
+
+### Initiative Table Features
+- **▶**: Current turn indicator
+- **Class Icons**: 🪓 Barbarian, ⚔️ Fighter, 🧙 Wizard, etc.
+- **HP Bars**: Visual health representation with 8 segments
+- **HP Numbers**: Current/Max for exact values
+- **❗**: Low health warning (<25% HP)
+- **💀**: Defeated indicator (0 HP)
+
+## Benefits
+1. **Dice Transparency**: Everyone can see all rolls immediately
+2. **Quick Status Check**: Table format shows all combatant status at a glance
+3. **Combat Flow**: Recent actions show the flow of battle
+4. **Visual Indicators**: Icons and bars make status instantly recognizable
+5. **Compact Display**: All information fits in a single embed

--- a/internal/handlers/discord/combat/combat_display.go
+++ b/internal/handlers/discord/combat/combat_display.go
@@ -22,65 +22,68 @@ func BuildInitiativeDisplay(enc *entities.Encounter) string {
 
 	// Show combatants in initiative order
 	for i, id := range enc.TurnOrder {
-		if c, exists := enc.Combatants[id]; exists && c.IsActive {
-			// Current turn indicator
-			if i == enc.Turn {
-				sb.WriteString("\u001b[1;33m▶ ") // Bold yellow for current turn
-			} else {
-				sb.WriteString("  ")
-			}
-
-			// Initiative score
-			sb.WriteString(fmt.Sprintf("%2d", c.Initiative))
-			sb.WriteString(" │ ")
-
-			// Name with type coloring
-			if c.Type == entities.CombatantTypeMonster {
-				sb.WriteString("\u001b[1;31m") // Bold red for monsters
-			} else {
-				sb.WriteString("\u001b[1;32m") // Bold green for players
-			}
-
-			nameDisplay := c.Name
-			if c.Type == entities.CombatantTypePlayer && c.Class != "" {
-				nameDisplay = fmt.Sprintf("%s (%s)", c.Name, c.Class)
-			}
-			if len(nameDisplay) > 21 {
-				nameDisplay = nameDisplay[:18] + "..."
-			}
-			sb.WriteString(fmt.Sprintf("%-21s", nameDisplay))
-			sb.WriteString("\u001b[0m") // Reset color
-
-			sb.WriteString(" │ ")
-
-			// HP with color based on health
-			hpPercent := float64(c.CurrentHP) / float64(c.MaxHP)
-			if hpPercent > 0.5 {
-				sb.WriteString("\u001b[32m") // Green
-			} else if hpPercent > 0.25 {
-				sb.WriteString("\u001b[33m") // Yellow
-			} else if c.CurrentHP > 0 {
-				sb.WriteString("\u001b[31m") // Red
-			} else {
-				sb.WriteString("\u001b[90m") // Gray for dead
-			}
-
-			hpDisplay := fmt.Sprintf("%3d/%-3d", c.CurrentHP, c.MaxHP)
-			sb.WriteString(hpDisplay)
-			sb.WriteString("\u001b[0m") // Reset color
-
-			sb.WriteString(" │ ")
-
-			// AC
-			sb.WriteString(fmt.Sprintf("%2d", c.AC))
-
-			// End turn indicator if current
-			if i == enc.Turn {
-				sb.WriteString("\u001b[0m") // Ensure color reset
-			}
-
-			sb.WriteString("\n")
+		c, exists := enc.Combatants[id]
+		if !exists || !c.IsActive {
+			continue
 		}
+
+		// Current turn indicator
+		if i == enc.Turn {
+			sb.WriteString("\u001b[1;33m▶ ") // Bold yellow for current turn
+		} else {
+			sb.WriteString("  ")
+		}
+
+		// Initiative score
+		sb.WriteString(fmt.Sprintf("%2d", c.Initiative))
+		sb.WriteString(" │ ")
+
+		// Name with type coloring
+		if c.Type == entities.CombatantTypeMonster {
+			sb.WriteString("\u001b[1;31m") // Bold red for monsters
+		} else {
+			sb.WriteString("\u001b[1;32m") // Bold green for players
+		}
+
+		nameDisplay := c.Name
+		if c.Type == entities.CombatantTypePlayer && c.Class != "" {
+			nameDisplay = fmt.Sprintf("%s (%s)", c.Name, c.Class)
+		}
+		if len(nameDisplay) > 21 {
+			nameDisplay = nameDisplay[:18] + "..."
+		}
+		sb.WriteString(fmt.Sprintf("%-21s", nameDisplay))
+		sb.WriteString("\u001b[0m") // Reset color
+
+		sb.WriteString(" │ ")
+
+		// HP with color based on health
+		hpPercent := float64(c.CurrentHP) / float64(c.MaxHP)
+		if hpPercent > 0.5 {
+			sb.WriteString("\u001b[32m") // Green
+		} else if hpPercent > 0.25 {
+			sb.WriteString("\u001b[33m") // Yellow
+		} else if c.CurrentHP > 0 {
+			sb.WriteString("\u001b[31m") // Red
+		} else {
+			sb.WriteString("\u001b[90m") // Gray for dead
+		}
+
+		hpDisplay := fmt.Sprintf("%3d/%-3d", c.CurrentHP, c.MaxHP)
+		sb.WriteString(hpDisplay)
+		sb.WriteString("\u001b[0m") // Reset color
+
+		sb.WriteString(" │ ")
+
+		// AC
+		sb.WriteString(fmt.Sprintf("%2d", c.AC))
+
+		// End turn indicator if current
+		if i == enc.Turn {
+			sb.WriteString("\u001b[0m") // Ensure color reset
+		}
+
+		sb.WriteString("\n")
 	}
 
 	sb.WriteString("```")

--- a/internal/handlers/discord/combat/combat_display.go
+++ b/internal/handlers/discord/combat/combat_display.go
@@ -1,0 +1,116 @@
+package combat
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+)
+
+// BuildInitiativeDisplay creates a formatted initiative order display
+func BuildInitiativeDisplay(enc *entities.Encounter) string {
+	var sb strings.Builder
+
+	// Use ANSI color codes for better visual distinction
+	sb.WriteString("```ansi\n")
+
+	// Header with color
+	sb.WriteString("\u001b[1;36m") // Bold cyan for header
+	sb.WriteString("Init │ Name                  │ HP         │ AC \n")
+	sb.WriteString("─────┼───────────────────────┼────────────┼────\n")
+	sb.WriteString("\u001b[0m") // Reset color
+
+	// Show combatants in initiative order
+	for i, id := range enc.TurnOrder {
+		if c, exists := enc.Combatants[id]; exists && c.IsActive {
+			// Current turn indicator
+			if i == enc.Turn {
+				sb.WriteString("\u001b[1;33m▶ ") // Bold yellow for current turn
+			} else {
+				sb.WriteString("  ")
+			}
+
+			// Initiative score
+			sb.WriteString(fmt.Sprintf("%2d", c.Initiative))
+			sb.WriteString(" │ ")
+
+			// Name with type coloring
+			if c.Type == entities.CombatantTypeMonster {
+				sb.WriteString("\u001b[1;31m") // Bold red for monsters
+			} else {
+				sb.WriteString("\u001b[1;32m") // Bold green for players
+			}
+
+			nameDisplay := c.Name
+			if c.Type == entities.CombatantTypePlayer && c.Class != "" {
+				nameDisplay = fmt.Sprintf("%s (%s)", c.Name, c.Class)
+			}
+			if len(nameDisplay) > 21 {
+				nameDisplay = nameDisplay[:18] + "..."
+			}
+			sb.WriteString(fmt.Sprintf("%-21s", nameDisplay))
+			sb.WriteString("\u001b[0m") // Reset color
+
+			sb.WriteString(" │ ")
+
+			// HP with color based on health
+			hpPercent := float64(c.CurrentHP) / float64(c.MaxHP)
+			if hpPercent > 0.5 {
+				sb.WriteString("\u001b[32m") // Green
+			} else if hpPercent > 0.25 {
+				sb.WriteString("\u001b[33m") // Yellow
+			} else if c.CurrentHP > 0 {
+				sb.WriteString("\u001b[31m") // Red
+			} else {
+				sb.WriteString("\u001b[90m") // Gray for dead
+			}
+
+			hpDisplay := fmt.Sprintf("%3d/%-3d", c.CurrentHP, c.MaxHP)
+			sb.WriteString(hpDisplay)
+			sb.WriteString("\u001b[0m") // Reset color
+
+			sb.WriteString(" │ ")
+
+			// AC
+			sb.WriteString(fmt.Sprintf("%2d", c.AC))
+
+			// End turn indicator if current
+			if i == enc.Turn {
+				sb.WriteString("\u001b[0m") // Ensure color reset
+			}
+
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString("```")
+	return sb.String()
+}
+
+// BuildCombatSummaryDisplay creates a summary of the current combat state
+func BuildCombatSummaryDisplay(enc *entities.Encounter) string {
+	var sb strings.Builder
+
+	// Count active combatants by type
+	var activeMonsters, activePlayers int
+	for _, c := range enc.Combatants {
+		if c.IsActive {
+			if c.Type == entities.CombatantTypeMonster {
+				activeMonsters++
+			} else {
+				activePlayers++
+			}
+		}
+	}
+
+	sb.WriteString(fmt.Sprintf("⚔️ **Round %d** | ", enc.Round))
+	sb.WriteString(fmt.Sprintf("🛡️ Players: %d | ", activePlayers))
+	sb.WriteString(fmt.Sprintf("🐉 Monsters: %d", activeMonsters))
+
+	// Add current turn info
+	if current := enc.GetCurrentCombatant(); current != nil {
+		sb.WriteString(fmt.Sprintf("\n🎯 **%s's turn**", current.Name))
+	}
+
+	return sb.String()
+}

--- a/internal/handlers/discord/combat/combat_display_test.go
+++ b/internal/handlers/discord/combat/combat_display_test.go
@@ -1,0 +1,167 @@
+package combat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildInitiativeDisplay(t *testing.T) {
+	// Create test encounter
+	enc := &entities.Encounter{
+		ID:     "test-enc",
+		Name:   "Test Combat",
+		Round:  2,
+		Turn:   1, // Second combatant's turn
+		Status: entities.EncounterStatusActive,
+		Combatants: map[string]*entities.Combatant{
+			"c1": {
+				ID:         "c1",
+				Name:       "Grunk",
+				Class:      "Barbarian",
+				Type:       entities.CombatantTypePlayer,
+				Initiative: 18,
+				AC:         16,
+				MaxHP:      50,
+				CurrentHP:  45,
+				IsActive:   true,
+			},
+			"c2": {
+				ID:         "c2",
+				Name:       "Goblin",
+				Type:       entities.CombatantTypeMonster,
+				Initiative: 15,
+				AC:         13,
+				MaxHP:      12,
+				CurrentHP:  3,
+				IsActive:   true,
+			},
+			"c3": {
+				ID:         "c3",
+				Name:       "Thorin",
+				Class:      "Fighter",
+				Type:       entities.CombatantTypePlayer,
+				Initiative: 10,
+				AC:         18,
+				MaxHP:      40,
+				CurrentHP:  40,
+				IsActive:   true,
+			},
+		},
+		TurnOrder: []string{"c1", "c2", "c3"},
+	}
+
+	display := BuildInitiativeDisplay(enc)
+
+	// Check that it contains expected elements
+	assert.Contains(t, display, "```ansi")
+	assert.Contains(t, display, "Init")
+	assert.Contains(t, display, "Name")
+	assert.Contains(t, display, "HP")
+	assert.Contains(t, display, "AC")
+
+	// Check for combatants
+	assert.Contains(t, display, "Grunk (Barbarian)")
+	assert.Contains(t, display, "Goblin")
+	assert.Contains(t, display, "Thorin (Fighter)")
+
+	// Check that current turn indicator is present
+	assert.Contains(t, display, "▶")
+
+	// Verify color codes are present (ANSI escape sequences)
+	assert.Contains(t, display, "\u001b[")
+}
+
+func TestBuildCombatSummaryDisplay(t *testing.T) {
+	enc := &entities.Encounter{
+		Round: 3,
+		Combatants: map[string]*entities.Combatant{
+			"c1": {
+				Name:     "Player1",
+				Type:     entities.CombatantTypePlayer,
+				IsActive: true,
+			},
+			"c2": {
+				Name:     "Player2",
+				Type:     entities.CombatantTypePlayer,
+				IsActive: true,
+			},
+			"c3": {
+				Name:     "Goblin",
+				Type:     entities.CombatantTypeMonster,
+				IsActive: true,
+			},
+			"c4": {
+				Name:     "Orc",
+				Type:     entities.CombatantTypeMonster,
+				IsActive: false, // Dead
+			},
+		},
+		TurnOrder: []string{"c1", "c2", "c3"},
+		Turn:      0,
+	}
+
+	summary := BuildCombatSummaryDisplay(enc)
+
+	assert.Contains(t, summary, "Round 3")
+	assert.Contains(t, summary, "Players: 2")
+	assert.Contains(t, summary, "Monsters: 1") // Only 1 active
+	assert.Contains(t, summary, "Player1's turn")
+}
+
+func TestInitiativeDisplay_ColorCoding(t *testing.T) {
+	enc := &entities.Encounter{
+		Combatants: map[string]*entities.Combatant{
+			"c1": {
+				ID:         "c1",
+				Name:       "HealthyPlayer",
+				Type:       entities.CombatantTypePlayer,
+				Initiative: 20,
+				AC:         15,
+				MaxHP:      40,
+				CurrentHP:  40, // Full health
+				IsActive:   true,
+			},
+			"c2": {
+				ID:         "c2",
+				Name:       "HurtPlayer",
+				Type:       entities.CombatantTypePlayer,
+				Initiative: 15,
+				AC:         14,
+				MaxHP:      40,
+				CurrentHP:  15, // Less than 50%
+				IsActive:   true,
+			},
+			"c3": {
+				ID:         "c3",
+				Name:       "CriticalMonster",
+				Type:       entities.CombatantTypeMonster,
+				Initiative: 10,
+				AC:         12,
+				MaxHP:      20,
+				CurrentHP:  3, // Less than 25%
+				IsActive:   true,
+			},
+		},
+		TurnOrder: []string{"c1", "c2", "c3"},
+		Turn:      0,
+	}
+
+	display := BuildInitiativeDisplay(enc)
+
+	// Split into lines for easier testing
+	lines := strings.Split(display, "\n")
+
+	// Find each combatant's line and check for appropriate color codes
+	for _, line := range lines {
+		if strings.Contains(line, "HealthyPlayer") {
+			assert.Contains(t, line, "\u001b[32m") // Green for healthy
+		} else if strings.Contains(line, "HurtPlayer") {
+			assert.Contains(t, line, "\u001b[33m") // Yellow for hurt
+		} else if strings.Contains(line, "CriticalMonster") {
+			assert.Contains(t, line, "\u001b[31m") // Red for critical
+		}
+	}
+}

--- a/internal/handlers/discord/combat/embed_builders.go
+++ b/internal/handlers/discord/combat/embed_builders.go
@@ -17,18 +17,14 @@ func BuildCombatStatusEmbed(enc *entities.Encounter, monsterActions []*encounter
 
 // BuildCombatStatusEmbedForPlayer creates a player-focused combat status embed
 func BuildCombatStatusEmbedForPlayer(enc *entities.Encounter, monsterActions []*encounter.AttackResult, playerName string) *discordgo.MessageEmbed {
-	current := enc.GetCurrentCombatant()
-
 	embed := &discordgo.MessageEmbed{
 		Title:  fmt.Sprintf("⚔️ Combat - Round %d", enc.Round),
 		Color:  0x3498db,
 		Fields: []*discordgo.MessageEmbedField{},
 	}
 
-	// Current turn
-	if current != nil {
-		embed.Description = fmt.Sprintf("**%s's turn** (HP: %d/%d)", current.Name, current.CurrentHP, current.MaxHP)
-	}
+	// Use combat summary for description
+	embed.Description = BuildCombatSummaryDisplay(enc)
 
 	// Create round summary if we have actions
 	if len(monsterActions) > 0 && playerName != "" {
@@ -72,46 +68,9 @@ func BuildCombatStatusEmbedForPlayer(enc *entities.Encounter, monsterActions []*
 		}
 	}
 
-	// Active combatants
-	var enemies, allies strings.Builder
-	for _, c := range enc.Combatants {
-		if !c.IsActive {
-			continue
-		}
-
-		hpBar := getHPBar(c.CurrentHP, c.MaxHP)
-
-		if c.Type == entities.CombatantTypeMonster {
-			line := fmt.Sprintf("%s **%s** - %d/%d HP\n", hpBar, c.Name, c.CurrentHP, c.MaxHP)
-			enemies.WriteString(line)
-		} else {
-			// For players, show class icon, name, class, HP, and AC
-			classIcon := getClassIcon(c.Class)
-			classInfo := ""
-			if c.Class != "" {
-				classInfo = fmt.Sprintf(" (%s)", c.Class)
-			}
-			line := fmt.Sprintf("%s %s **%s**%s - %d/%d HP | AC %d\n",
-				classIcon, hpBar, c.Name, classInfo, c.CurrentHP, c.MaxHP, c.AC)
-			allies.WriteString(line)
-		}
-	}
-
-	if enemies.Len() > 0 {
-		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:   "🐉 Enemies",
-			Value:  enemies.String(),
-			Inline: true,
-		})
-	}
-
-	if allies.Len() > 0 {
-		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:   "🛡️ Allies",
-			Value:  allies.String(),
-			Inline: true,
-		})
-	}
+	// Add initiative order using the new field format
+	initiativeFields := BuildInitiativeFields(enc)
+	embed.Fields = append(embed.Fields, initiativeFields...)
 
 	// Add combat history - last 5 entries
 	if len(enc.CombatLog) > 0 {

--- a/internal/handlers/discord/combat/handler.go
+++ b/internal/handlers/discord/combat/handler.go
@@ -366,20 +366,25 @@ func (h *Handler) handleNextTurn(s *discordgo.Session, i *discordgo.InteractionC
 		}
 	}
 
-	// Build detailed combat embed (like view status)
-	embed := buildDetailedCombatEmbed(enc)
+	// Build combat status embed with clearer display
+	embed := BuildCombatStatusEmbed(enc, monsterResults)
 
-	// Add monster actions summary if any
+	// Add round complete indicator if needed
 	if len(monsterResults) > 0 {
-		var monsterSummary strings.Builder
+		var roundActions strings.Builder
+		roundActions.WriteString("🔄 **Monster Actions This Turn:**\n")
 		for _, ma := range monsterResults {
 			if ma.Hit {
-				monsterSummary.WriteString(fmt.Sprintf("👹 **%s** attacked %s for %d damage!\n", ma.AttackerName, ma.TargetName, ma.Damage))
+				if ma.TargetDefeated {
+					roundActions.WriteString(fmt.Sprintf("• ⚔️ **%s** → **%s** | HIT 🩸 **%d** 💀\n", ma.AttackerName, ma.TargetName, ma.Damage))
+				} else {
+					roundActions.WriteString(fmt.Sprintf("• ⚔️ **%s** → **%s** | HIT 🩸 **%d**\n", ma.AttackerName, ma.TargetName, ma.Damage))
+				}
 			} else {
-				monsterSummary.WriteString(fmt.Sprintf("👹 **%s** missed %s!\n", ma.AttackerName, ma.TargetName))
+				roundActions.WriteString(fmt.Sprintf("• ❌ **%s** → **%s** | MISS\n", ma.AttackerName, ma.TargetName))
 			}
 		}
-		embed.Description = monsterSummary.String() + "\n" + embed.Description
+		embed.Description = roundActions.String() + "\n" + embed.Description
 	}
 
 	// Check whose turn it is now
@@ -753,11 +758,43 @@ func (h *Handler) handleMyActions(s *discordgo.Session, i *discordgo.Interaction
 		isMyTurn = current.ID == playerCombatant.ID
 	}
 
-	// Build personalized action embed - focused on actions only
+	// Build personalized action embed with combat summary
 	embed := &discordgo.MessageEmbed{
 		Title:       fmt.Sprintf("🎯 %s's Action Controller", playerCombatant.Name),
 		Description: "Choose your action:",
 		Color:       0x3498db, // Blue
+		Fields:      []*discordgo.MessageEmbedField{},
+	}
+
+	// Add player's current status
+	hpBar := getHPBar(playerCombatant.CurrentHP, playerCombatant.MaxHP)
+	statusValue := fmt.Sprintf("%s HP: **%d/%d** | AC: **%d**", hpBar, playerCombatant.CurrentHP, playerCombatant.MaxHP, playerCombatant.AC)
+	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+		Name:   "🛡️ Your Status",
+		Value:  statusValue,
+		Inline: false,
+	})
+
+	// Show recent combat actions involving this player
+	if len(enc.CombatLog) > 0 {
+		var playerActions strings.Builder
+		count := 0
+		// Search backwards through combat log for actions involving this player
+		for i := len(enc.CombatLog) - 1; i >= 0 && count < 5; i-- {
+			logEntry := enc.CombatLog[i]
+			if strings.Contains(logEntry, playerCombatant.Name) {
+				playerActions.WriteString("• " + logEntry + "\n")
+				count++
+			}
+		}
+
+		if playerActions.Len() > 0 {
+			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+				Name:   "📜 Your Recent Actions",
+				Value:  playerActions.String(),
+				Inline: false,
+			})
+		}
 	}
 
 	// Build action buttons - always enabled unless combat is not active

--- a/internal/handlers/discord/combat/handler.go
+++ b/internal/handlers/discord/combat/handler.go
@@ -201,8 +201,8 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 		return respondEditError(s, i, "Failed to get updated encounter", err)
 	}
 
-	// Build detailed combat embed (like view status)
-	embed := buildDetailedCombatEmbed(enc)
+	// Use the standard combat embed for consistency
+	embed := BuildCombatStatusEmbed(enc, result.MonsterActions)
 
 	// Add attack result summary at the top
 	if result.PlayerAttack != nil {

--- a/internal/handlers/discord/combat/handler.go
+++ b/internal/handlers/discord/combat/handler.go
@@ -202,7 +202,7 @@ func (h *Handler) handleSelectTarget(s *discordgo.Session, i *discordgo.Interact
 	}
 
 	// Use the standard combat embed for consistency
-	embed := BuildCombatStatusEmbed(enc, result.MonsterActions)
+	embed := BuildCombatStatusEmbed(enc, result.MonsterAttacks)
 
 	// Add attack result summary at the top
 	if result.PlayerAttack != nil {
@@ -760,7 +760,7 @@ func (h *Handler) handleMyActions(s *discordgo.Session, i *discordgo.Interaction
 
 	// Use the standard combat status embed for consistency
 	embed := BuildCombatStatusEmbedForPlayer(enc, nil, playerCombatant.Name)
-	
+
 	// Update title and description for personalized view
 	embed.Title = fmt.Sprintf("🎯 %s's Action Controller", playerCombatant.Name)
 	embed.Description = "Choose your action:"

--- a/internal/handlers/discord/combat/initiative_table.go
+++ b/internal/handlers/discord/combat/initiative_table.go
@@ -22,9 +22,9 @@ func BuildInitiativeFields(enc *entities.Encounter) []*discordgo.MessageEmbedFie
 		if c, exists := enc.Combatants[id]; exists && c.IsActive {
 			// Current turn indicator and initiative in fixed width
 			if i == enc.Turn {
-				sb.WriteString(fmt.Sprintf("▶%2d", c.Initiative))
+				sb.WriteString(fmt.Sprintf("▶%-2d", c.Initiative))
 			} else {
-				sb.WriteString(fmt.Sprintf(" %2d", c.Initiative))
+				sb.WriteString(fmt.Sprintf(" %-2d", c.Initiative))
 			}
 			sb.WriteString(" │")
 

--- a/internal/handlers/discord/combat/initiative_table.go
+++ b/internal/handlers/discord/combat/initiative_table.go
@@ -15,8 +15,8 @@ func BuildInitiativeFields(enc *entities.Encounter) []*discordgo.MessageEmbedFie
 
 	// Use ANSI code block for color support
 	sb.WriteString("```ansi\n")
-	sb.WriteString("Init│Name              │HP              │ AC\n")
-	sb.WriteString("────┼──────────────────┼────────────────┼───\n")
+	sb.WriteString("Init│Name              │HP               │ AC\n")
+	sb.WriteString("────┼──────────────────┼─────────────────┼───\n")
 
 	for i, id := range enc.TurnOrder {
 		if c, exists := enc.Combatants[id]; exists && c.IsActive {
@@ -58,7 +58,7 @@ func BuildInitiativeFields(enc *entities.Encounter) []*discordgo.MessageEmbedFie
 			} else {
 				sb.WriteString("\u001b[31m") // Red
 			}
-			
+
 			hpBar := getCompactHPBar(c.CurrentHP, c.MaxHP)
 			sb.WriteString(hpBar)
 			sb.WriteString(fmt.Sprintf(" %3d/%-3d", c.CurrentHP, c.MaxHP))

--- a/internal/handlers/discord/combat/initiative_table.go
+++ b/internal/handlers/discord/combat/initiative_table.go
@@ -15,8 +15,8 @@ func BuildInitiativeFields(enc *entities.Encounter) []*discordgo.MessageEmbedFie
 
 	// Use ANSI code block for color support
 	sb.WriteString("```ansi\n")
-	sb.WriteString("Init│Name              │HP          │AC\n")
-	sb.WriteString("────┼──────────────────┼────────────┼──\n")
+	sb.WriteString("Init│Name              │HP              │AC\n")
+	sb.WriteString("────┼──────────────────┼────────────────┼──\n")
 
 	for i, id := range enc.TurnOrder {
 		if c, exists := enc.Combatants[id]; exists && c.IsActive {

--- a/internal/handlers/discord/combat/initiative_table.go
+++ b/internal/handlers/discord/combat/initiative_table.go
@@ -1,0 +1,219 @@
+package combat
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	"github.com/bwmarrin/discordgo"
+)
+
+// BuildInitiativeFields creates Discord embed fields for initiative order
+func BuildInitiativeFields(enc *entities.Encounter) []*discordgo.MessageEmbedField {
+	var fields []*discordgo.MessageEmbedField
+
+	// Build two columns: Players and Monsters
+	var playerLines, monsterLines strings.Builder
+
+	for i, id := range enc.TurnOrder {
+		if c, exists := enc.Combatants[id]; exists && c.IsActive {
+			// Turn indicator
+			turnMarker := ""
+			if i == enc.Turn {
+				turnMarker = "▶ "
+			}
+
+			// HP visual indicator
+			hpIcon := getHPIcon(c.CurrentHP, c.MaxHP)
+
+			// Name (truncated if needed)
+			name := c.Name
+			if len(name) > 15 {
+				name = name[:12] + "..."
+			}
+
+			// Build the line
+			line := fmt.Sprintf("%s`%2d` %s **%s**\n├─ %s HP: %d/%d | AC: %d\n",
+				turnMarker,
+				c.Initiative,
+				hpIcon,
+				name,
+				getHPBar(c.CurrentHP, c.MaxHP),
+				c.CurrentHP,
+				c.MaxHP,
+				c.AC,
+			)
+
+			// Add to appropriate column
+			if c.Type == entities.CombatantTypePlayer {
+				playerLines.WriteString(line)
+				if c.Class != "" {
+					playerLines.WriteString(fmt.Sprintf("└─ *%s*\n\n", c.Class))
+				} else {
+					playerLines.WriteString("\n")
+				}
+			} else {
+				monsterLines.WriteString(line)
+				monsterLines.WriteString("\n")
+			}
+		}
+	}
+
+	// Add player field if there are players
+	if playerLines.Len() > 0 {
+		fields = append(fields, &discordgo.MessageEmbedField{
+			Name:   "🛡️ Party Members",
+			Value:  playerLines.String(),
+			Inline: true,
+		})
+	}
+
+	// Add monster field if there are monsters
+	if monsterLines.Len() > 0 {
+		fields = append(fields, &discordgo.MessageEmbedField{
+			Name:   "⚔️ Enemies",
+			Value:  monsterLines.String(),
+			Inline: true,
+		})
+	}
+
+	return fields
+}
+
+// BuildCompactInitiativeDisplay creates a compact single-line display for each combatant
+func BuildCompactInitiativeDisplay(enc *entities.Encounter) string {
+	var sb strings.Builder
+
+	sb.WriteString("```css\n")
+	sb.WriteString("[Initiative Order]\n")
+	sb.WriteString("─────────────────────────────────────────\n")
+
+	for i, id := range enc.TurnOrder {
+		if c, exists := enc.Combatants[id]; exists && c.IsActive {
+			// Current turn indicator
+			if i == enc.Turn {
+				sb.WriteString("▶ ")
+			} else {
+				sb.WriteString("  ")
+			}
+
+			// Initiative
+			sb.WriteString(fmt.Sprintf("[%2d] ", c.Initiative))
+
+			// Name with type indicator
+			typeIcon := "👤"
+			if c.Type == entities.CombatantTypeMonster {
+				typeIcon = "👹"
+			}
+
+			name := c.Name
+			if len(name) > 12 {
+				name = name[:10] + ".."
+			}
+			sb.WriteString(fmt.Sprintf("%s %-12s ", typeIcon, name))
+
+			// HP bar
+			sb.WriteString(fmt.Sprintf("HP[%s] ", getCompactHPBar(c.CurrentHP, c.MaxHP)))
+
+			// AC
+			sb.WriteString(fmt.Sprintf("AC:%2d", c.AC))
+
+			// Status effects (future enhancement)
+			// if c.HasConditions() {
+			//     sb.WriteString(" [!]")
+			// }
+
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString("```")
+	return sb.String()
+}
+
+// getHPIcon returns an emoji based on health percentage
+func getHPIcon(current, maxHP int) string {
+	if maxHP == 0 {
+		return "💀"
+	}
+	percent := float64(current) / float64(maxHP)
+	if percent > 0.75 {
+		return "💚" // Healthy
+	} else if percent > 0.5 {
+		return "💛" // Good
+	} else if percent > 0.25 {
+		return "🧡" // Hurt
+	} else if current > 0 {
+		return "❤️" // Critical
+	}
+	return "💀" // Dead
+}
+
+// getCompactHPBar returns a compact visual HP bar
+func getCompactHPBar(current, maxHP int) string {
+	if maxHP == 0 {
+		return "████" // All black for dead
+	}
+
+	percent := float64(current) / float64(maxHP)
+	filled := int(percent * 8) // 8 character bar
+
+	bar := ""
+	for i := 0; i < 8; i++ {
+		if i < filled {
+			bar += "▰"
+		} else {
+			bar += "▱"
+		}
+	}
+
+	return bar
+}
+
+// BuildDetailedCombatant creates a detailed view of a single combatant
+// This could be shown when someone clicks a button or uses a command
+func BuildDetailedCombatant(c *entities.Combatant) *discordgo.MessageEmbed {
+	color := 0x3498db // Blue default
+	if c.Type == entities.CombatantTypeMonster {
+		color = 0xe74c3c // Red for monsters
+	}
+
+	embed := &discordgo.MessageEmbed{
+		Title: fmt.Sprintf("%s %s", getHPIcon(c.CurrentHP, c.MaxHP), c.Name),
+		Color: color,
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "📊 Stats",
+				Value:  fmt.Sprintf("**HP:** %d/%d\n**AC:** %d\n**Initiative:** %d", c.CurrentHP, c.MaxHP, c.AC, c.Initiative),
+				Inline: true,
+			},
+		},
+	}
+
+	if c.Class != "" {
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "⚔️ Class",
+			Value:  c.Class,
+			Inline: true,
+		})
+	}
+
+	// Add visual HP bar
+	hpPercent := float64(c.CurrentHP) / float64(c.MaxHP)
+	hpBar := ""
+	for i := 0; i < 10; i++ {
+		if float64(i)/10 < hpPercent {
+			hpBar += "🟩"
+		} else {
+			hpBar += "⬜"
+		}
+	}
+
+	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+		Name:   "💚 Health",
+		Value:  hpBar,
+		Inline: false,
+	})
+
+	return embed
+}

--- a/internal/handlers/discord/combat/initiative_table.go
+++ b/internal/handlers/discord/combat/initiative_table.go
@@ -15,8 +15,8 @@ func BuildInitiativeFields(enc *entities.Encounter) []*discordgo.MessageEmbedFie
 
 	// Use ANSI code block for color support
 	sb.WriteString("```ansi\n")
-	sb.WriteString("Init│Name              │HP              │AC\n")
-	sb.WriteString("────┼──────────────────┼────────────────┼──\n")
+	sb.WriteString("Init│Name              │HP              │ AC\n")
+	sb.WriteString("────┼──────────────────┼────────────────┼───\n")
 
 	for i, id := range enc.TurnOrder {
 		if c, exists := enc.Combatants[id]; exists && c.IsActive {

--- a/internal/handlers/discord/combat/initiative_table.go
+++ b/internal/handlers/discord/combat/initiative_table.go
@@ -15,8 +15,8 @@ func BuildInitiativeFields(enc *entities.Encounter) []*discordgo.MessageEmbedFie
 
 	// Use monospace code block for proper alignment
 	sb.WriteString("```\n")
-	sb.WriteString("Init │ Name              │ HP          │ AC\n")
-	sb.WriteString("─────┼───────────────────┼─────────────┼────\n")
+	sb.WriteString("Init │ Name                │ HP            │ AC\n")
+	sb.WriteString("─────┼─────────────────────┼───────────────┼────\n")
 
 	for i, id := range enc.TurnOrder {
 		if c, exists := enc.Combatants[id]; exists && c.IsActive {
@@ -31,24 +31,29 @@ func BuildInitiativeFields(enc *entities.Encounter) []*discordgo.MessageEmbedFie
 			sb.WriteString(fmt.Sprintf("%2d", c.Initiative))
 			sb.WriteString("  │ ")
 
-			// Name (truncated if needed)
-			name := c.Name
-			if len(name) > 17 {
-				name = name[:14] + "..."
-			}
-			// Add class icon for players
+			// Name with icon (truncated if needed)
+			icon := ""
 			if c.Type == entities.CombatantTypePlayer {
-				name = getClassIcon(c.Class) + " " + name
+				icon = getClassIcon(c.Class)
 			} else {
-				name = "🐉 " + name // Monster icon
+				icon = "🐉" // Monster icon
 			}
-			sb.WriteString(fmt.Sprintf("%-17s", name))
+
+			name := c.Name
+			maxNameLen := 16 // Leave room for icon and spacing
+			if len(name) > maxNameLen {
+				name = name[:maxNameLen-3] + "..."
+			}
+
+			// Format: "icon name" padded to 19 chars total
+			nameStr := fmt.Sprintf("%s %s", icon, name)
+			sb.WriteString(fmt.Sprintf("%-19s", nameStr))
 			sb.WriteString(" │ ")
 
-			// HP with visual bar
+			// HP with visual bar - ensure consistent width
 			hpBar := getCompactHPBar(c.CurrentHP, c.MaxHP)
 			hpStr := fmt.Sprintf("%s %3d/%-3d", hpBar, c.CurrentHP, c.MaxHP)
-			sb.WriteString(hpStr)
+			sb.WriteString(fmt.Sprintf("%-13s", hpStr))
 			sb.WriteString(" │ ")
 
 			// AC

--- a/internal/handlers/discord/combat/round_summary.go
+++ b/internal/handlers/discord/combat/round_summary.go
@@ -1,0 +1,157 @@
+package combat
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RoundSummary tracks combat actions for a single round
+type RoundSummary struct {
+	Round         int
+	PlayerActions map[string]*PlayerRoundInfo // key is player name
+}
+
+// PlayerRoundInfo tracks a player's combat stats for the round
+type PlayerRoundInfo struct {
+	Name         string
+	DamageDealt  int
+	DamageTaken  int
+	AttacksMade  []AttackInfo
+	AttacksRecvd []AttackInfo
+}
+
+// AttackInfo represents a single attack
+type AttackInfo struct {
+	AttackerName string
+	TargetName   string
+	Damage       int
+	Hit          bool
+	Critical     bool
+	WeaponName   string
+}
+
+// NewRoundSummary creates a new round summary
+func NewRoundSummary(round int) *RoundSummary {
+	return &RoundSummary{
+		Round:         round,
+		PlayerActions: make(map[string]*PlayerRoundInfo),
+	}
+}
+
+// RecordAttack records an attack in the round summary
+func (rs *RoundSummary) RecordAttack(attack AttackInfo) {
+	// Record for attacker (if player)
+	if _, exists := rs.PlayerActions[attack.AttackerName]; !exists {
+		rs.PlayerActions[attack.AttackerName] = &PlayerRoundInfo{
+			Name:         attack.AttackerName,
+			AttacksMade:  []AttackInfo{},
+			AttacksRecvd: []AttackInfo{},
+		}
+	}
+
+	// Record for target (if player)
+	if _, exists := rs.PlayerActions[attack.TargetName]; !exists {
+		rs.PlayerActions[attack.TargetName] = &PlayerRoundInfo{
+			Name:         attack.TargetName,
+			AttacksMade:  []AttackInfo{},
+			AttacksRecvd: []AttackInfo{},
+		}
+	}
+
+	// Update attacker stats
+	if attacker := rs.PlayerActions[attack.AttackerName]; attacker != nil {
+		attacker.AttacksMade = append(attacker.AttacksMade, attack)
+		if attack.Hit {
+			attacker.DamageDealt += attack.Damage
+		}
+	}
+
+	// Update target stats
+	if target := rs.PlayerActions[attack.TargetName]; target != nil {
+		target.AttacksRecvd = append(target.AttacksRecvd, attack)
+		if attack.Hit {
+			target.DamageTaken += attack.Damage
+		}
+	}
+}
+
+// GetPlayerSummary returns a formatted summary for a specific player
+func (rs *RoundSummary) GetPlayerSummary(playerName string) string {
+	info, exists := rs.PlayerActions[playerName]
+	if !exists {
+		return ""
+	}
+
+	var sb strings.Builder
+
+	// Your attacks
+	if len(info.AttacksMade) > 0 {
+		sb.WriteString("**Your Attacks:**\n")
+		for _, atk := range info.AttacksMade {
+			icon := "❌"
+			if atk.Hit {
+				if atk.Critical {
+					icon = "💥"
+				} else {
+					icon = "⚔️"
+				}
+			}
+			sb.WriteString(fmt.Sprintf("%s %s → **%s** ", icon, atk.WeaponName, atk.TargetName))
+			if atk.Hit {
+				sb.WriteString(fmt.Sprintf("🩸 **%d** damage", atk.Damage))
+			} else {
+				sb.WriteString("**MISS**")
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	// Attacks against you
+	if len(info.AttacksRecvd) > 0 {
+		sb.WriteString("\n**Attacks Against You:**\n")
+		for _, atk := range info.AttacksRecvd {
+			icon := "🛡️"
+			if atk.Hit {
+				icon = "🩸"
+			}
+			sb.WriteString(fmt.Sprintf("%s **%s** → You ", icon, atk.AttackerName))
+			if atk.Hit {
+				sb.WriteString(fmt.Sprintf("**%d** damage", atk.Damage))
+			} else {
+				sb.WriteString("**MISS**")
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	// Summary
+	sb.WriteString("\n**Round Summary:**\n")
+	sb.WriteString(fmt.Sprintf("💔 Damage Taken: **%d**\n", info.DamageTaken))
+	sb.WriteString(fmt.Sprintf("⚔️ Damage Dealt: **%d**\n", info.DamageDealt))
+
+	return sb.String()
+}
+
+// GetRoundOverview returns a general overview of the round
+func (rs *RoundSummary) GetRoundOverview() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("**Round %d Overview:**\n", rs.Round))
+
+	for _, player := range rs.PlayerActions {
+		if player.DamageDealt > 0 || player.DamageTaken > 0 {
+			sb.WriteString(fmt.Sprintf("• **%s**: ", player.Name))
+			if player.DamageDealt > 0 {
+				sb.WriteString(fmt.Sprintf("dealt **%d** ", player.DamageDealt))
+			}
+			if player.DamageTaken > 0 {
+				if player.DamageDealt > 0 {
+					sb.WriteString("| ")
+				}
+				sb.WriteString(fmt.Sprintf("took **%d**", player.DamageTaken))
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	return sb.String()
+}

--- a/internal/handlers/discord/combat/round_summary_test.go
+++ b/internal/handlers/discord/combat/round_summary_test.go
@@ -1,0 +1,111 @@
+package combat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoundSummary(t *testing.T) {
+	t.Run("RecordAttack tracks damage correctly", func(t *testing.T) {
+		rs := NewRoundSummary(1)
+
+		// Record a hit
+		rs.RecordAttack(AttackInfo{
+			AttackerName: "Grunk",
+			TargetName:   "Goblin",
+			Damage:       8,
+			Hit:          true,
+			WeaponName:   "Longsword",
+		})
+
+		// Record a miss
+		rs.RecordAttack(AttackInfo{
+			AttackerName: "Goblin",
+			TargetName:   "Grunk",
+			Hit:          false,
+			WeaponName:   "Shortsword",
+		})
+
+		// Record another hit against player
+		rs.RecordAttack(AttackInfo{
+			AttackerName: "Orc",
+			TargetName:   "Grunk",
+			Damage:       6,
+			Hit:          true,
+			WeaponName:   "Greataxe",
+		})
+
+		// Check player stats
+		grunkInfo := rs.PlayerActions["Grunk"]
+		assert.NotNil(t, grunkInfo)
+		assert.Equal(t, 8, grunkInfo.DamageDealt)
+		assert.Equal(t, 6, grunkInfo.DamageTaken)
+		assert.Len(t, grunkInfo.AttacksMade, 1)
+		assert.Len(t, grunkInfo.AttacksRecvd, 2)
+	})
+
+	t.Run("GetPlayerSummary formats correctly", func(t *testing.T) {
+		rs := NewRoundSummary(2)
+
+		// Record some attacks
+		rs.RecordAttack(AttackInfo{
+			AttackerName: "Thorin",
+			TargetName:   "Goblin",
+			Damage:       10,
+			Hit:          true,
+			Critical:     true,
+			WeaponName:   "Warhammer",
+		})
+
+		rs.RecordAttack(AttackInfo{
+			AttackerName: "Goblin",
+			TargetName:   "Thorin",
+			Damage:       4,
+			Hit:          true,
+			WeaponName:   "Scimitar",
+		})
+
+		summary := rs.GetPlayerSummary("Thorin")
+		assert.Contains(t, summary, "Your Attacks:")
+		assert.Contains(t, summary, "💥 Warhammer → **Goblin** 🩸 **10** damage")
+		assert.Contains(t, summary, "Attacks Against You:")
+		assert.Contains(t, summary, "🩸 **Goblin** → You **4** damage")
+		assert.Contains(t, summary, "Damage Taken: **4**")
+		assert.Contains(t, summary, "Damage Dealt: **10**")
+	})
+
+	t.Run("GetRoundOverview shows all players", func(t *testing.T) {
+		rs := NewRoundSummary(3)
+
+		// Multiple players attacking
+		rs.RecordAttack(AttackInfo{
+			AttackerName: "Grunk",
+			TargetName:   "Dragon",
+			Damage:       12,
+			Hit:          true,
+			WeaponName:   "Greatsword",
+		})
+
+		rs.RecordAttack(AttackInfo{
+			AttackerName: "Thorin",
+			TargetName:   "Dragon",
+			Damage:       8,
+			Hit:          true,
+			WeaponName:   "Warhammer",
+		})
+
+		rs.RecordAttack(AttackInfo{
+			AttackerName: "Dragon",
+			TargetName:   "Grunk",
+			Damage:       15,
+			Hit:          true,
+			WeaponName:   "Bite",
+		})
+
+		overview := rs.GetRoundOverview()
+		assert.Contains(t, overview, "Round 3 Overview:")
+		assert.Contains(t, overview, "**Grunk**: dealt **12** | took **15**")
+		assert.Contains(t, overview, "**Thorin**: dealt **8**")
+	})
+}

--- a/internal/handlers/discord/dnd/dungeon/enter_room.go
+++ b/internal/handlers/discord/dnd/dungeon/enter_room.go
@@ -241,7 +241,8 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 				UserID:      botID,
 				ActionIndex: 0, // Use first action
 			}
-			attackResult, err := h.services.EncounterService.PerformAttack(
+			var attackResult *encounter.AttackResult
+			attackResult, err = h.services.EncounterService.PerformAttack(
 				context.Background(),
 				attackInput,
 			)
@@ -606,20 +607,4 @@ func (h *EnterRoomHandler) generateCombatRoom(difficulty string, roomNumber int)
 		Monsters:    monsters,
 		Challenge:   fmt.Sprintf("Defeat all %d enemies!", len(monsters)),
 	}
-}
-
-// getHPBar returns an emoji HP indicator
-func getHPBar(current, maxValue int) string {
-	if maxValue == 0 {
-		return "💀"
-	}
-	percent := float64(current) / float64(maxValue)
-	if percent > 0.5 {
-		return "🟢"
-	} else if percent > 0.25 {
-		return "🟡"
-	} else if current > 0 {
-		return "🔴"
-	}
-	return "💀"
 }

--- a/internal/handlers/discord/dnd/dungeon/enter_room.go
+++ b/internal/handlers/discord/dnd/dungeon/enter_room.go
@@ -7,9 +7,9 @@ import (
 	"math/rand"
 	"strings"
 
-	"github.com/KirkDiggler/dnd-bot-discord/internal/dice"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/entities/damage"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/combat"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/services"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/services/encounter"
 	"github.com/bwmarrin/discordgo"
@@ -214,7 +214,7 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 	}
 
 	// Process initial monster turns if they go first
-	var monsterActions []string
+	var monsterAttackResults []*encounter.AttackResult
 	for enc.Status == entities.EncounterStatusActive {
 		current := enc.GetCurrentCombatant()
 		if current == nil || current.Type != entities.CombatantTypeMonster {
@@ -233,53 +233,25 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 			}
 		}
 
-		if target != nil && len(current.Actions) > 0 {
-			// Use first available action
-			action := current.Actions[0]
-
-			// Roll attack
-			attackResult, rollErr := dice.Roll(1, 20, 0)
-			if rollErr != nil {
-				log.Printf("Failed to roll attack: %v", rollErr)
-				//TODO: Handle error
+		if target != nil {
+			// Use PerformAttack for consistency with combat flow
+			attackInput := &encounter.AttackInput{
+				EncounterID: enc.ID,
+				AttackerID:  current.ID,
+				TargetID:    target.ID,
+				UserID:      botID,
+				ActionIndex: 0, // Use first action
 			}
-			attackRoll := attackResult.Total
-			totalAttack := attackRoll + action.AttackBonus
-
-			// Check if hit
-			hit := totalAttack >= target.AC
-			if hit && len(action.Damage) > 0 {
-				totalDamage := 0
-				for _, dmg := range action.Damage {
-					diceCount := dmg.DiceCount
-					if attackRoll == 20 { // Critical hit doubles dice
-						diceCount *= 2
-					}
-					rollResult, rollErr := dice.Roll(diceCount, dmg.DiceSize, dmg.Bonus)
-					if rollErr != nil {
-						log.Printf("Failed to roll damage: %v", rollErr)
-						//TODO: Handle error
-					}
-					totalDamage += rollResult.Total
-				}
-
-				// Apply damage
-				err = h.services.EncounterService.ApplyDamage(context.Background(), enc.ID, target.ID, botID, totalDamage)
-				if err != nil {
-					log.Printf("Error applying initial monster damage: %v", err)
-				}
-
-				monsterActions = append(monsterActions, fmt.Sprintf("%s attacks %s with %s for %d damage!", current.Name, target.Name, action.Name, totalDamage))
-			} else {
-				monsterActions = append(monsterActions, fmt.Sprintf("%s misses %s with %s!", current.Name, target.Name, action.Name))
+			attackResult, err := h.services.EncounterService.PerformAttack(
+				context.Background(),
+				attackInput,
+			)
+			if err != nil {
+				log.Printf("Error performing monster attack: %v", err)
+			} else if attackResult != nil {
+				monsterAttackResults = append(monsterAttackResults, attackResult)
+				log.Printf("Monster attack result: %s", attackResult.LogEntry)
 			}
-		}
-
-		// Advance turn
-		err = h.services.EncounterService.NextTurn(context.Background(), enc.ID, botID)
-		if err != nil {
-			log.Printf("Error advancing initial monster turn: %v", err)
-			break
 		}
 
 		// Re-get encounter for next iteration
@@ -290,86 +262,16 @@ func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.I
 		}
 	}
 
-	// Build detailed combat display
-	embed := &discordgo.MessageEmbed{
-		Title:       fmt.Sprintf("⚔️ %s", enc.Name),
-		Description: fmt.Sprintf("**%s**\n\n**Status:** %s | **Round:** %d", room.Description, enc.Status, enc.Round),
-		Color:       0xe74c3c, // Red
-		Fields:      []*discordgo.MessageEmbedField{},
-	}
+	// Use the combat embed builder for consistent formatting
+	embed := combat.BuildCombatStatusEmbed(enc, monsterAttackResults)
 
-	// Show initiative rolls sorted by turn order
-	if len(enc.CombatLog) > 0 && len(enc.TurnOrder) > 0 {
-		var initiativeRolls strings.Builder
-		// Show initiative rolls in turn order (highest to lowest)
-		for position, combatantID := range enc.TurnOrder {
-			if combatant, exists := enc.Combatants[combatantID]; exists {
-				// Find the log entry for this combatant
-				for _, logEntry := range enc.CombatLog {
-					if strings.Contains(logEntry, combatant.Name) && strings.Contains(logEntry, "rolls initiative:") {
-						initiativeRolls.WriteString(fmt.Sprintf("%d. %s\n", position+1, logEntry))
-						break
-					}
-				}
-			}
-		}
-		if initiativeRolls.Len() > 0 {
-			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-				Name:   "🎲 Initiative Rolls (Sorted by Turn Order)",
-				Value:  initiativeRolls.String(),
-				Inline: false,
-			})
-		}
+	// Add room description to the embed
+	if embed.Description != "" {
+		embed.Description = fmt.Sprintf("**%s**\n\n%s", room.Description, embed.Description)
+	} else {
+		embed.Description = fmt.Sprintf("**%s**", room.Description)
 	}
-
-	// Turn order with details
-	var turnOrder strings.Builder
-	for i, id := range enc.TurnOrder {
-		if c, exists := enc.Combatants[id]; exists && c.IsActive {
-			prefix := "  "
-			if i == enc.Turn {
-				prefix = "▶️"
-			}
-			turnOrder.WriteString(fmt.Sprintf("%s %s (Init: %d)\n", prefix, c.Name, c.Initiative))
-		}
-	}
-
-	if turnOrder.Len() > 0 {
-		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:   "📋 Initiative Order",
-			Value:  turnOrder.String(),
-			Inline: false,
-		})
-	}
-
-	// All combatants with details (like View Status)
-	var combatantList strings.Builder
-	for _, c := range enc.Combatants {
-		if c.IsActive {
-			hpBar := getHPBar(c.CurrentHP, c.MaxHP)
-			status := fmt.Sprintf("%s %d/%d HP | AC %d", hpBar, c.CurrentHP, c.MaxHP, c.AC)
-			combatantList.WriteString(fmt.Sprintf("**%s**\n%s\n\n", c.Name, status))
-		}
-	}
-
-	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-		Name:   "⚔️ Combatants",
-		Value:  combatantList.String(),
-		Inline: false,
-	})
-
-	// Show monster actions if any occurred
-	if len(monsterActions) > 0 {
-		var recentActions strings.Builder
-		for _, action := range monsterActions {
-			recentActions.WriteString("• " + action + "\n")
-		}
-		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:   "📜 Recent Actions",
-			Value:  recentActions.String(),
-			Inline: false,
-		})
-	}
+	embed.Title = fmt.Sprintf("⚔️ %s", enc.Name)
 
 	// Check if it's a player's turn
 	isPlayerTurn := false

--- a/internal/services/character/integration_test.go
+++ b/internal/services/character/integration_test.go
@@ -33,8 +33,6 @@ func TestCharacterCreationFlow_Integration(t *testing.T) {
 	realmID := "realm456"
 
 	t.Run("full character creation flow", func(t *testing.T) {
-		// TODO: Fix mock setup for Update method expectation
-		t.Skip("Skipping test - mock expectations for Update need to be fixed")
 		// Step 1: Get or create draft character
 		draftChar := &entities.Character{
 			ID:            "draft123",
@@ -178,7 +176,8 @@ func TestCharacterCreationFlow_Integration(t *testing.T) {
 				},
 				WeaponCategory: "Martial",
 				WeaponRange:    "Melee",
-			}, nil)
+			}, nil).
+			Times(2) // Once for UpdateDraftCharacter, once for FinalizeDraftCharacter (starting equipment)
 
 		mockClient.EXPECT().
 			GetEquipment("chain-mail").

--- a/internal/services/encounter/attack_simple_test.go
+++ b/internal/services/encounter/attack_simple_test.go
@@ -139,12 +139,12 @@ func TestPerformAttack_MonsterVsMonster_WithMockDice(t *testing.T) {
 	assert.Equal(t, 7, result.TargetNewHP) // 15 - 8 = 7
 	assert.False(t, result.TargetDefeated)
 
-	// Check the log entry
-	assert.Contains(t, result.LogEntry, "Goblin attacks Orc")
-	assert.Contains(t, result.LogEntry, "Scimitar")
-	assert.Contains(t, result.LogEntry, "15 + 4 = **19**")
-	assert.Contains(t, result.LogEntry, "HIT")
-	assert.Contains(t, result.LogEntry, "8 slashing damage")
+	// Check the log entry with new format
+	assert.Contains(t, result.LogEntry, "⚔️ **Goblin** → **Orc**")
+	assert.Contains(t, result.LogEntry, "d20:15+4=19")
+	assert.Contains(t, result.LogEntry, "vs AC:13")
+	assert.Contains(t, result.LogEntry, "HIT 🩸 **8**")
+	assert.Contains(t, result.LogEntry, "[6]") // damage roll
 }
 
 func TestPerformAttack_UnarmedStrike_WithMockDice(t *testing.T) {

--- a/internal/services/encounter/attack_simple_test.go
+++ b/internal/services/encounter/attack_simple_test.go
@@ -144,7 +144,7 @@ func TestPerformAttack_MonsterVsMonster_WithMockDice(t *testing.T) {
 	assert.Contains(t, result.LogEntry, "HIT 🩸 **8**")
 	assert.Contains(t, result.LogEntry, "||d20:15+4=19")
 	assert.Contains(t, result.LogEntry, "vs AC:13")
-	assert.Contains(t, result.LogEntry, "dmg:1d8: [6]||") // damage roll in spoiler
+	assert.Contains(t, result.LogEntry, "dmg:1d6: [6]||") // damage roll in spoiler
 }
 
 func TestPerformAttack_UnarmedStrike_WithMockDice(t *testing.T) {

--- a/internal/services/encounter/attack_simple_test.go
+++ b/internal/services/encounter/attack_simple_test.go
@@ -139,12 +139,12 @@ func TestPerformAttack_MonsterVsMonster_WithMockDice(t *testing.T) {
 	assert.Equal(t, 7, result.TargetNewHP) // 15 - 8 = 7
 	assert.False(t, result.TargetDefeated)
 
-	// Check the log entry with new format
+	// Check the log entry with spoiler format
 	assert.Contains(t, result.LogEntry, "⚔️ **Goblin** → **Orc**")
-	assert.Contains(t, result.LogEntry, "d20:15+4=19")
-	assert.Contains(t, result.LogEntry, "vs AC:13")
 	assert.Contains(t, result.LogEntry, "HIT 🩸 **8**")
-	assert.Contains(t, result.LogEntry, "[6]") // damage roll
+	assert.Contains(t, result.LogEntry, "||d20:15+4=19")
+	assert.Contains(t, result.LogEntry, "vs AC:13")
+	assert.Contains(t, result.LogEntry, "dmg:[6]||") // damage roll in spoiler
 }
 
 func TestPerformAttack_UnarmedStrike_WithMockDice(t *testing.T) {

--- a/internal/services/encounter/attack_simple_test.go
+++ b/internal/services/encounter/attack_simple_test.go
@@ -144,7 +144,7 @@ func TestPerformAttack_MonsterVsMonster_WithMockDice(t *testing.T) {
 	assert.Contains(t, result.LogEntry, "HIT 🩸 **8**")
 	assert.Contains(t, result.LogEntry, "||d20:15+4=19")
 	assert.Contains(t, result.LogEntry, "vs AC:13")
-	assert.Contains(t, result.LogEntry, "dmg:[6]||") // damage roll in spoiler
+	assert.Contains(t, result.LogEntry, "dmg:1d8: [6]||") // damage roll in spoiler
 }
 
 func TestPerformAttack_UnarmedStrike_WithMockDice(t *testing.T) {

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -864,12 +864,12 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 				// Common weapon dice - this is a simple heuristic
 				switch {
 				case len(result.DamageRolls) == 1:
-					if result.Damage-result.DamageBonus <= 8 {
-						diceExpr = "1d8"
+					if result.Damage-result.DamageBonus <= 4 {
+						diceExpr = "1d4"
 					} else if result.Damage-result.DamageBonus <= 6 {
 						diceExpr = "1d6"
-					} else if result.Damage-result.DamageBonus <= 4 {
-						diceExpr = "1d4"
+					} else if result.Damage-result.DamageBonus <= 8 {
+						diceExpr = "1d8"
 					} else {
 						diceExpr = "1d10"
 					}

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -877,7 +877,7 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 					diceExpr = "2d6" // Common for greatsword crits, etc.
 				}
 			}
-			
+
 			damageRollStr = fmt.Sprintf("%s: [%d", diceExpr, result.DamageRolls[0])
 			for i := 1; i < len(result.DamageRolls); i++ {
 				damageRollStr += fmt.Sprintf(",%d", result.DamageRolls[i])

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -858,25 +858,42 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 		// Format damage dice with expression (e.g., "1d8: [4]+2")
 		damageRollStr := ""
 		if len(result.DamageRolls) > 0 {
-			// Try to reconstruct dice expression from the weapon name
-			diceExpr := fmt.Sprintf("%dd?", len(result.DamageRolls))
-			if result.WeaponName != "" {
-				// Common weapon dice - this is a simple heuristic
-				switch {
-				case len(result.DamageRolls) == 1:
-					if result.Damage-result.DamageBonus <= 4 {
-						diceExpr = "1d4"
-					} else if result.Damage-result.DamageBonus <= 6 {
-						diceExpr = "1d6"
-					} else if result.Damage-result.DamageBonus <= 8 {
-						diceExpr = "1d8"
-					} else {
-						diceExpr = "1d10"
-					}
-				case len(result.DamageRolls) == 2:
-					diceExpr = "2d6" // Common for greatsword crits, etc.
+			// Try to reconstruct dice expression from the damage rolls
+			// For critical hits, we have double the dice, so use half the roll count
+			diceCount := len(result.DamageRolls)
+			if result.Critical && diceCount > 1 {
+				diceCount /= 2
+			}
+
+			// Determine dice size from the maximum possible roll value
+			// This is more accurate than trying to guess from damage totals
+			maxRoll := 0
+			for _, roll := range result.DamageRolls[:diceCount] {
+				if roll > maxRoll {
+					maxRoll = roll
 				}
 			}
+
+			// Map max roll to dice size
+			var diceSize int
+			switch {
+			case maxRoll <= 4:
+				diceSize = 4
+			case maxRoll <= 6:
+				diceSize = 6
+			case maxRoll <= 8:
+				diceSize = 8
+			case maxRoll <= 10:
+				diceSize = 10
+			case maxRoll <= 12:
+				diceSize = 12
+			case maxRoll <= 20:
+				diceSize = 20
+			default:
+				diceSize = maxRoll // Fallback for unusual dice
+			}
+
+			diceExpr := fmt.Sprintf("%dd%d", diceCount, diceSize)
 
 			damageRollStr = fmt.Sprintf("%s: [%d", diceExpr, result.DamageRolls[0])
 			for i := 1; i < len(result.DamageRolls); i++ {

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -856,24 +856,19 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 	// Generate log entry
 	if result.Hit {
 		if result.Critical {
-			result.LogEntry = fmt.Sprintf("⚔️ **CRITICAL HIT!** %s attacks %s with %s: %d + %d = **%d** vs AC %d - **HIT** for %d %s damage!",
-				result.AttackerName, result.TargetName, result.WeaponName,
-				result.AttackRoll, result.AttackBonus, result.TotalAttack, result.TargetAC,
-				result.Damage, result.DamageType)
+			result.LogEntry = fmt.Sprintf("💥 **%s** → **%s** | CRIT! 🩸 **%d** damage",
+				result.AttackerName, result.TargetName, result.Damage)
 		} else {
-			result.LogEntry = fmt.Sprintf("⚔️ %s attacks %s with %s: %d + %d = **%d** vs AC %d - **HIT** for %d %s damage",
-				result.AttackerName, result.TargetName, result.WeaponName,
-				result.AttackRoll, result.AttackBonus, result.TotalAttack, result.TargetAC,
-				result.Damage, result.DamageType)
+			result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | HIT 🩸 **%d** damage",
+				result.AttackerName, result.TargetName, result.Damage)
 		}
 
 		if result.TargetDefeated {
-			result.LogEntry += fmt.Sprintf("\n💀 **%s has been defeated!**", result.TargetName)
+			result.LogEntry += " 💀"
 		}
 	} else {
-		result.LogEntry = fmt.Sprintf("⚔️ %s attacks %s with %s: %d + %d = **%d** vs AC %d - **MISS**",
-			result.AttackerName, result.TargetName, result.WeaponName,
-			result.AttackRoll, result.AttackBonus, result.TotalAttack, result.TargetAC)
+		result.LogEntry = fmt.Sprintf("❌ **%s** → **%s** | MISS",
+			result.AttackerName, result.TargetName)
 	}
 
 	// Add to combat log

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -853,22 +853,40 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 		}
 	}
 
-	// Generate log entry
+	// Generate log entry with dice rolls
 	if result.Hit {
+		// Format damage dice (e.g., "2d6+3" -> "[4,5]+3")
+		damageRollStr := ""
+		if len(result.DamageRolls) > 0 {
+			damageRollStr = fmt.Sprintf("[%d", result.DamageRolls[0])
+			for i := 1; i < len(result.DamageRolls); i++ {
+				damageRollStr += fmt.Sprintf(",%d", result.DamageRolls[i])
+			}
+			damageRollStr += "]"
+			if result.DamageBonus != 0 {
+				damageRollStr += fmt.Sprintf("%+d", result.DamageBonus)
+			}
+		}
+
 		if result.Critical {
-			result.LogEntry = fmt.Sprintf("💥 **%s** → **%s** | CRIT! 🩸 **%d** damage",
-				result.AttackerName, result.TargetName, result.Damage)
+			result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | d20:**%d**%+d=%d vs AC:%d | 💥 CRIT! 🩸 **%d** %s",
+				result.AttackerName, result.TargetName,
+				result.AttackRoll, result.AttackBonus, result.TotalAttack, result.TargetAC,
+				result.Damage, damageRollStr)
 		} else {
-			result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | HIT 🩸 **%d** damage",
-				result.AttackerName, result.TargetName, result.Damage)
+			result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | d20:%d%+d=%d vs AC:%d | HIT 🩸 **%d** %s",
+				result.AttackerName, result.TargetName,
+				result.AttackRoll, result.AttackBonus, result.TotalAttack, result.TargetAC,
+				result.Damage, damageRollStr)
 		}
 
 		if result.TargetDefeated {
 			result.LogEntry += " 💀"
 		}
 	} else {
-		result.LogEntry = fmt.Sprintf("❌ **%s** → **%s** | MISS",
-			result.AttackerName, result.TargetName)
+		result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | d20:%d%+d=%d vs AC:%d | ❌ MISS",
+			result.AttackerName, result.TargetName,
+			result.AttackRoll, result.AttackBonus, result.TotalAttack, result.TargetAC)
 	}
 
 	// Add to combat log

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -869,22 +869,24 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 		}
 
 		if result.Critical {
-			result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | d20:**%d**%+d=%d vs AC:%d | 💥 CRIT! 🩸 **%d** %s",
+			result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | 💥 CRIT! 🩸 **%d** ||d20:**%d**%+d=%d vs AC:%d, dmg:%s||",
 				result.AttackerName, result.TargetName,
+				result.Damage,
 				result.AttackRoll, result.AttackBonus, result.TotalAttack, result.TargetAC,
-				result.Damage, damageRollStr)
+				damageRollStr)
 		} else {
-			result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | d20:%d%+d=%d vs AC:%d | HIT 🩸 **%d** %s",
+			result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | HIT 🩸 **%d** ||d20:%d%+d=%d vs AC:%d, dmg:%s||",
 				result.AttackerName, result.TargetName,
+				result.Damage,
 				result.AttackRoll, result.AttackBonus, result.TotalAttack, result.TargetAC,
-				result.Damage, damageRollStr)
+				damageRollStr)
 		}
 
 		if result.TargetDefeated {
 			result.LogEntry += " 💀"
 		}
 	} else {
-		result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | d20:%d%+d=%d vs AC:%d | ❌ MISS",
+		result.LogEntry = fmt.Sprintf("⚔️ **%s** → **%s** | ❌ MISS ||d20:%d%+d=%d vs AC:%d||",
 			result.AttackerName, result.TargetName,
 			result.AttackRoll, result.AttackBonus, result.TotalAttack, result.TargetAC)
 	}


### PR DESCRIPTION
Fixes #123

## Summary
This PR significantly improves combat message clarity by adding visual indicators, implementing a formatted initiative table, and showing dice rolls in spoiler tags.

## Changes Made

### Visual Indicators
- Added emoji indicators: 🩸 for damage, ❌ for miss, 💥 for critical hits
- Color-coded HP bars in initiative display (green/yellow/red based on health)
- Defeated combatants now stay visible in gray (like players do)

### Initiative Display
- Created ASCII-formatted initiative table showing turn order
- Displays HP, AC, and visual health indicators
- Current turn marked with ▶ indicator
- Truncates long names to prevent wrapping

### Combat Messages
- Dice rolls now shown in Discord spoiler tags
- Attack format: `⚔️ **Attacker** → **Target** | HIT 🩸 **8** ||d20:15+4=19 vs AC:13, dmg:1d6:[6]+2||`
- Unified combat embed format across all views (shared and ephemeral)
- Added d12 damage dice support

### Bug Fixes
- Fixed duplicate monster attacks (goblin attacking twice)
- Fixed skeleton not attacking 
- Fixed inconsistent display between ephemeral and shared messages
- Fixed dice expression logic (was checking <=8 before <=6, making some conditions unreachable)

### Additional Improvements
- Also fixed character creation integration test (Issue #126) - mock expectations now handle starting equipment

## Testing
- All unit tests pass
- Integration tests fixed and passing
- Manual testing completed with multiplayer combat

## Screenshots
Initiative display shows formatted table with health bars and combat information in a clean, easy-to-read format.