### PR TITLE
Fix: Character creation integration test mock expectations

### DIFF
--- a/internal/services/character/integration_test.go
+++ b/internal/services/character/integration_test.go
@@ -33,8 +33,6 @@ func TestCharacterCreationFlow_Integration(t *testing.T) {
 	realmID := "realm456"
 
 	t.Run("full character creation flow", func(t *testing.T) {
-		// TODO: Fix mock setup for Update method expectation
-		t.Skip("Skipping test - mock expectations for Update need to be fixed")
 		// Step 1: Get or create draft character
 		draftChar := &entities.Character{
 			ID:            "draft123",
@@ -178,7 +176,8 @@ func TestCharacterCreationFlow_Integration(t *testing.T) {
 				},
 				WeaponCategory: "Martial",
 				WeaponRange:    "Melee",
-			}, nil)
+			}, nil).
+			Times(2) // Once for UpdateDraftCharacter, once for FinalizeDraftCharacter (starting equipment)
 
 		mockClient.EXPECT().
 			GetEquipment("chain-mail").


### PR DESCRIPTION
Fixes #126

## Summary
This PR fixes the character creation integration test that was previously skipped due to incorrect mock expectations.

## Problem
The test didn't account for the fighter class's starting equipment (longsword) being fetched during .

## Solution
- Added  to the longsword mock expectation
- Added explanatory comment about why it's fetched twice
- Removed the TODO and skip statement

## Testing
- Integration test now passes
- All character service tests pass