### PR TITLE
Fix: Apply rage damage bonus to melee attacks

### DIFF
--- a/internal/entities/character.go
+++ b/internal/entities/character.go
@@ -124,7 +124,19 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 			}
 
 			attackBonus := abilityBonus + proficiencyBonus
-			damageBonus := abilityBonus // Only ability modifier applies to damage
+			damageBonus := abilityBonus // Base damage bonus from ability modifier
+
+			// Apply damage bonuses from active effects (e.g., rage)
+			if c.Resources != nil {
+				effectBonus := c.Resources.GetTotalDamageBonus("melee")
+				if effectBonus > 0 {
+					log.Printf("Applying damage bonus from effects: +%d", effectBonus)
+					damageBonus += effectBonus
+				}
+			}
+
+			log.Printf("Final attack bonus: +%d (ability: %d, proficiency: %d)", attackBonus, abilityBonus, proficiencyBonus)
+			log.Printf("Final damage bonus: +%d", damageBonus)
 
 			// Roll the attack
 			var attak1 *attack.Result
@@ -162,6 +174,11 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 
 					offHandAttackBonus := offHandAbilityBonus + offHandProficiencyBonus
 					offHandDamageBonus := offHandAbilityBonus
+
+					// Apply damage bonuses from active effects (e.g., rage) to off-hand
+					if c.Resources != nil {
+						offHandDamageBonus += c.Resources.GetTotalDamageBonus("melee")
+					}
 
 					attak2, err := attack.RollAttack(offHandAttackBonus, offHandDamageBonus, offWeap.Damage)
 					if err != nil {
@@ -209,6 +226,15 @@ func (c *Character) Attack() ([]*attack.Result, error) {
 
 			attackBonus := abilityBonus + proficiencyBonus
 			damageBonus := abilityBonus
+
+			// Apply damage bonuses from active effects (e.g., rage)
+			if c.Resources != nil {
+				effectBonus := c.Resources.GetTotalDamageBonus("melee")
+				if effectBonus > 0 {
+					log.Printf("Applying damage bonus from effects: +%d", effectBonus)
+					damageBonus += effectBonus
+				}
+			}
 
 			// Two-handed weapons often have special damage
 			var dmg *damage.Damage
@@ -271,6 +297,17 @@ func (c *Character) improvisedMelee() (*attack.Result, error) {
 	if c.Attributes != nil && c.Attributes[AttributeStrength] != nil {
 		bonus = c.Attributes[AttributeStrength].Bonus
 	}
+
+	// Apply damage bonuses from active effects (e.g., rage) to improvised attacks
+	damageBonus := bonus
+	if c.Resources != nil {
+		effectBonus := c.Resources.GetTotalDamageBonus("melee")
+		if effectBonus > 0 {
+			log.Printf("Applying damage bonus from effects to improvised attack: +%d", effectBonus)
+			damageBonus += effectBonus
+		}
+	}
+
 	attackRoll, err := dice.Roll(1, 20, 0)
 	if err != nil {
 		return nil, err
@@ -282,7 +319,7 @@ func (c *Character) improvisedMelee() (*attack.Result, error) {
 
 	return &attack.Result{
 		AttackRoll:   attackRoll.Total + bonus,
-		DamageRoll:   damageRoll.Total + bonus,
+		DamageRoll:   damageRoll.Total + damageBonus,
 		AttackType:   damage.TypeBludgeoning,
 		AttackResult: attackRoll,
 		DamageResult: damageRoll,

--- a/internal/entities/character_test.go
+++ b/internal/entities/character_test.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"testing"
 
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities/damage"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -311,4 +312,151 @@ func (s *suiteEquip) TestTwoHandedOverwritesSlots() {
 
 func TestSuiteEquip(t *testing.T) {
 	suite.Run(t, new(suiteEquip))
+}
+
+func TestCharacter_Attack_WithRageBonus(t *testing.T) {
+	// Create a barbarian character with a weapon
+	char := &Character{
+		Name:  "Ragnar",
+		Level: 1,
+		Class: &Class{Key: "barbarian", Name: "Barbarian"},
+		Attributes: map[Attribute]*AbilityScore{
+			AttributeStrength: {Score: 16, Bonus: 3}, // +3 STR modifier
+		},
+		EquippedSlots: map[Slot]Equipment{
+			SlotMainHand: &Weapon{
+				Base: BasicEquipment{
+					Key:  "greataxe",
+					Name: "Greataxe",
+				},
+				WeaponRange: "Melee",
+				Damage: &damage.Damage{
+					DiceCount:  1,
+					DiceSize:   12,
+					Bonus:      0,
+					DamageType: damage.TypeSlashing,
+				},
+			},
+		},
+		Proficiencies: map[ProficiencyType][]*Proficiency{
+			ProficiencyTypeWeapon: {
+				{Key: "greataxe", Name: "Greataxe"},
+			},
+		},
+	}
+
+	// Initialize resources
+	char.InitializeResources()
+
+	// Verify rage ability exists
+	rage, exists := char.Resources.Abilities["rage"]
+	if !exists {
+		t.Fatal("Rage ability not found")
+	}
+
+	// Activate rage (simulate the effect being added)
+	char.Resources.AddEffect(&ActiveEffect{
+		ID:           "rage-effect",
+		Name:         "Rage",
+		Source:       "rage",
+		DurationType: DurationTypeRounds,
+		Duration:     10,
+		Modifiers: []Modifier{
+			{
+				Type:        ModifierTypeDamageBonus,
+				Value:       2,
+				DamageTypes: []string{"melee"},
+			},
+		},
+	})
+
+	// Mark rage as active
+	rage.IsActive = true
+
+	// Perform attack
+	attacks, err := char.Attack()
+	if err != nil {
+		t.Fatalf("Attack failed: %v", err)
+	}
+
+	if len(attacks) != 1 {
+		t.Fatalf("Expected 1 attack, got %d", len(attacks))
+	}
+
+	attack := attacks[0]
+
+	// Attack roll should include:
+	// - STR bonus (+3)
+	// - Proficiency bonus (+2 at level 1)
+	// Total attack bonus should be +5
+	expectedAttackBonus := 5
+	actualAttackBonus := attack.AttackRoll - attack.AttackResult.Total
+	if actualAttackBonus != expectedAttackBonus {
+		t.Errorf("Expected attack bonus +%d, got +%d", expectedAttackBonus, actualAttackBonus)
+	}
+
+	// Damage roll should include:
+	// - STR bonus (+3)
+	// - Rage bonus (+2)
+	// Total damage bonus should be +5
+	expectedDamageBonus := 5
+	actualDamageBonus := attack.DamageRoll - attack.DamageResult.Total
+	if actualDamageBonus != expectedDamageBonus {
+		t.Errorf("Expected damage bonus +%d, got +%d (damage roll: %d, dice total: %d)",
+			expectedDamageBonus, actualDamageBonus, attack.DamageRoll, attack.DamageResult.Total)
+	}
+}
+
+func TestCharacter_Attack_WithoutRage(t *testing.T) {
+	// Create a barbarian character with a weapon but no rage active
+	char := &Character{
+		Name:  "Ragnar",
+		Level: 1,
+		Class: &Class{Key: "barbarian", Name: "Barbarian"},
+		Attributes: map[Attribute]*AbilityScore{
+			AttributeStrength: {Score: 16, Bonus: 3}, // +3 STR modifier
+		},
+		EquippedSlots: map[Slot]Equipment{
+			SlotMainHand: &Weapon{
+				Base: BasicEquipment{
+					Key:  "greataxe",
+					Name: "Greataxe",
+				},
+				WeaponRange: "Melee",
+				Damage: &damage.Damage{
+					DiceCount:  1,
+					DiceSize:   12,
+					Bonus:      0,
+					DamageType: damage.TypeSlashing,
+				},
+			},
+		},
+		Proficiencies: map[ProficiencyType][]*Proficiency{
+			ProficiencyTypeWeapon: {
+				{Key: "greataxe", Name: "Greataxe"},
+			},
+		},
+	}
+
+	// Initialize resources but don't activate rage
+	char.InitializeResources()
+
+	// Perform attack
+	attacks, err := char.Attack()
+	if err != nil {
+		t.Fatalf("Attack failed: %v", err)
+	}
+
+	if len(attacks) != 1 {
+		t.Fatalf("Expected 1 attack, got %d", len(attacks))
+	}
+
+	attack := attacks[0]
+
+	// Damage roll should only include STR bonus (+3), no rage bonus
+	expectedDamageBonus := 3
+	actualDamageBonus := attack.DamageRoll - attack.DamageResult.Total
+	if actualDamageBonus != expectedDamageBonus {
+		t.Errorf("Expected damage bonus +%d, got +%d", expectedDamageBonus, actualDamageBonus)
+	}
 }


### PR DESCRIPTION
## Summary
Fixes issue where rage ability was activating successfully but the +2 damage bonus was not being applied to melee attacks.

## Problem
User reported: "I went into rage, really cool but I should have gotten +2 on my attack right? I only got my str modifier"

The rage effect was being created with the correct damage bonus modifier, but the `Character.Attack()` method wasn't checking for active effects when calculating damage.

## Solution
- Modified `Attack()` method to check character resources for active effects
- Added `GetTotalDamageBonus("melee")` calls for all attack types:
  - Main hand weapon attacks
  - Off-hand weapon attacks
  - Two-handed weapon attacks
  - Improvised melee attacks
- Added comprehensive tests to verify rage damage bonus is correctly applied
- Added logging to help track when effect bonuses are applied

## Testing
- Added `TestCharacter_Attack_WithRageBonus` - verifies +2 damage is applied when raging
- Added `TestCharacter_Attack_WithoutRage` - verifies no bonus when not raging
- All existing tests continue to pass

## Example Log Output
```
2025/06/27 14:20:10 Applying damage bonus from effects: +2
2025/06/27 14:20:10 Final attack bonus: +5 (ability: 3, proficiency: 2)
2025/06/27 14:20:10 Final damage bonus: +5
```

The user will now see their rage damage bonus correctly applied to all melee attacks.

🤖 Generated with [Claude Code](https://claude.ai/code)