### PR TITLE
[ARCH] Add type-safe metadata access patterns

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture-improvement.md
+++ b/.github/ISSUE_TEMPLATE/architecture-improvement.md
@@ -1,0 +1,52 @@
+---
+name: Architecture Improvement
+about: Suggest improvements to code architecture, patterns, or internal APIs
+title: '[ARCH] '
+labels: 'architecture, enhancement'
+assignees: ''
+
+---
+
+## Problem Description
+<!-- Describe the current code pattern that needs improvement -->
+
+## Current Implementation
+<!-- Show code examples of the problematic pattern -->
+
+```go
+// Example of current implementation
+```
+
+## Proposed Solution
+<!-- Describe your proposed improvement -->
+
+```go
+// Example of improved implementation
+```
+
+## Benefits
+<!-- List the benefits of this improvement -->
+
+- [ ] Improved type safety
+- [ ] Reduced code duplication
+- [ ] Better error handling
+- [ ] Easier to test
+- [ ] More maintainable
+- [ ] Better performance
+
+## Scope
+<!-- What parts of the codebase would be affected? -->
+
+- Files affected:
+- Estimated effort:
+- Breaking changes:
+
+## Migration Strategy
+<!-- How would we migrate existing code? -->
+
+1. 
+2. 
+3. 
+
+## Additional Context
+<!-- Add any other context, examples, or screenshots -->

--- a/docs/architecture/metadata-refactoring.md
+++ b/docs/architecture/metadata-refactoring.md
@@ -1,0 +1,172 @@
+# Metadata Type Safety Refactoring
+
+## Overview
+
+This refactoring introduces type-safe metadata access patterns to replace error-prone type assertions throughout the codebase.
+
+## Before vs After
+
+### Before - Fragile Type Assertions
+
+```go
+// Checking session type
+if sessionType, ok := session.Metadata["sessionType"].(string); ok && sessionType == "dungeon" {
+    // Handle dungeon session
+}
+
+// Getting room number with multiple type checks
+roomNumber := 1
+if sess.Metadata != nil {
+    switch roomNum := sess.Metadata["roomNumber"].(type) {
+    case float64:
+        roomNumber = int(roomNum)
+    case int:
+        roomNumber = roomNum
+    }
+}
+
+// Nested checks for message IDs
+if freshSess != nil && freshSess.Metadata != nil {
+    if messageID, ok := freshSess.Metadata["lobbyMessageID"].(string); ok {
+        if channelID, ok := freshSess.Metadata["lobbyChannelID"].(string); ok {
+            // Use messageID and channelID
+        }
+    }
+}
+```
+
+### After - Clean, Type-Safe API
+
+```go
+// Checking session type
+if session.IsDungeon() {
+    // Handle dungeon session
+}
+
+// Getting room number with automatic type conversion
+roomNumber := sess.GetRoomNumber() // Returns 1 if not found
+
+// Clean metadata access with error handling
+messageID, msgErr := sess.Metadata.GetString(string(entities.MetadataKeyLobbyMessage))
+channelID, chanErr := sess.Metadata.GetString(string(entities.MetadataKeyLobbyChannel))
+if msgErr == nil && chanErr == nil {
+    // Use messageID and channelID
+}
+```
+
+## New Features
+
+### 1. Typed Metadata Access
+
+```go
+// Type-specific getters with error handling
+str, err := metadata.GetString("key")
+num, err := metadata.GetInt("key")
+bool, err := metadata.GetBool("key")
+
+// With defaults (no error handling needed)
+str := metadata.GetStringOrDefault("key", "default")
+num := metadata.GetIntOrDefault("key", 42)
+bool := metadata.GetBoolOrDefault("key", false)
+```
+
+### 2. Generic Access (Go 1.18+)
+
+```go
+// Type-safe generic access
+sessionType, err := entities.Get[string](metadata, "sessionType")
+roomNumber, err := entities.Get[int](metadata, "roomNumber")
+
+// With defaults
+difficulty := entities.GetOrDefault(metadata, "difficulty", "medium")
+```
+
+### 3. Session Type Constants
+
+```go
+const (
+    SessionTypeDungeon   SessionType = "dungeon"
+    SessionTypeCombat    SessionType = "combat"
+    SessionTypeRoleplay  SessionType = "roleplay"
+    SessionTypeOneShot   SessionType = "oneshot"
+)
+
+// Usage
+session.SetSessionType(entities.SessionTypeDungeon)
+if session.GetSessionType() == entities.SessionTypeDungeon {
+    // Handle dungeon
+}
+```
+
+### 4. Metadata Key Constants
+
+```go
+const (
+    MetadataKeySessionType  MetadataKey = "sessionType"
+    MetadataKeyDifficulty   MetadataKey = "difficulty"
+    MetadataKeyRoomNumber   MetadataKey = "roomNumber"
+    MetadataKeyLobbyMessage MetadataKey = "lobbyMessageID"
+    MetadataKeyLobbyChannel MetadataKey = "lobbyChannelID"
+)
+```
+
+## Benefits
+
+1. **Type Safety**: No more runtime panics from incorrect type assertions
+2. **Cleaner Code**: Reduced boilerplate and nested checks
+3. **Better Defaults**: Built-in default value handling
+4. **Consistency**: Standard patterns across the codebase
+5. **Discoverability**: Constants make it easy to find all metadata keys
+6. **Flexibility**: Generic methods support any type
+7. **Error Handling**: Clear error messages when types don't match
+
+## Migration Guide
+
+### Simple Type Checks
+
+```go
+// Old
+if sessionType, ok := session.Metadata["sessionType"].(string); ok && sessionType == "dungeon" {
+
+// New
+if session.IsDungeon() {
+```
+
+### Getting Values with Defaults
+
+```go
+// Old
+difficulty := "medium"
+if sess.Metadata != nil {
+    if diff, ok := sess.Metadata["difficulty"].(string); ok {
+        difficulty = diff
+    }
+}
+
+// New
+difficulty := sess.GetDifficulty() // Built-in default of "medium"
+```
+
+### Complex Type Conversions
+
+```go
+// Old
+roomNumber := 1
+switch roomNum := sess.Metadata["roomNumber"].(type) {
+case float64:
+    roomNumber = int(roomNum)
+case int:
+    roomNumber = roomNum
+}
+
+// New
+roomNumber := sess.GetRoomNumber() // Handles all conversions
+```
+
+## Future Improvements
+
+1. **Validation**: Add validation methods to ensure metadata consistency
+2. **Serialization**: Custom JSON marshaling/unmarshaling
+3. **Migrations**: Tools to migrate old metadata formats
+4. **Type Registration**: Register custom types for metadata values
+5. **Metadata Schemas**: Define expected metadata for different session types

--- a/internal/entities/metadata.go
+++ b/internal/entities/metadata.go
@@ -1,0 +1,148 @@
+package entities
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Metadata provides type-safe access to map[string]interface{} data
+type Metadata map[string]interface{}
+
+// GetString retrieves a string value from metadata
+func (m Metadata) GetString(key string) (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("metadata is nil")
+	}
+
+	value, exists := m[key]
+	if !exists {
+		return "", fmt.Errorf("key %q not found", key)
+	}
+
+	str, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("key %q is not a string (got %T)", key, value)
+	}
+
+	return str, nil
+}
+
+// GetStringOrDefault retrieves a string value or returns the default
+func (m Metadata) GetStringOrDefault(key, defaultValue string) string {
+	str, err := m.GetString(key)
+	if err != nil {
+		return defaultValue
+	}
+	return str
+}
+
+// GetInt retrieves an int value from metadata
+func (m Metadata) GetInt(key string) (int, error) {
+	if m == nil {
+		return 0, fmt.Errorf("metadata is nil")
+	}
+
+	value, exists := m[key]
+	if !exists {
+		return 0, fmt.Errorf("key %q not found", key)
+	}
+
+	// Handle various numeric types
+	switch v := value.(type) {
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	case string:
+		// Try to parse string as int
+		return strconv.Atoi(v)
+	default:
+		return 0, fmt.Errorf("key %q cannot be converted to int (got %T)", key, value)
+	}
+}
+
+// GetIntOrDefault retrieves an int value or returns the default
+func (m Metadata) GetIntOrDefault(key string, defaultValue int) int {
+	val, err := m.GetInt(key)
+	if err != nil {
+		return defaultValue
+	}
+	return val
+}
+
+// GetBool retrieves a bool value from metadata
+func (m Metadata) GetBool(key string) (bool, error) {
+	if m == nil {
+		return false, fmt.Errorf("metadata is nil")
+	}
+
+	value, exists := m[key]
+	if !exists {
+		return false, fmt.Errorf("key %q not found", key)
+	}
+
+	b, ok := value.(bool)
+	if !ok {
+		return false, fmt.Errorf("key %q is not a bool (got %T)", key, value)
+	}
+
+	return b, nil
+}
+
+// GetBoolOrDefault retrieves a bool value or returns the default
+func (m Metadata) GetBoolOrDefault(key string, defaultValue bool) bool {
+	val, err := m.GetBool(key)
+	if err != nil {
+		return defaultValue
+	}
+	return val
+}
+
+// Set sets a value in the metadata
+func (m Metadata) Set(key string, value interface{}) {
+	if m == nil {
+		return
+	}
+	m[key] = value
+}
+
+// Has checks if a key exists in metadata
+func (m Metadata) Has(key string) bool {
+	if m == nil {
+		return false
+	}
+	_, exists := m[key]
+	return exists
+}
+
+// Generic Get method using type parameters (requires Go 1.18+)
+func Get[T any](m Metadata, key string) (T, error) {
+	var zero T
+
+	if m == nil {
+		return zero, fmt.Errorf("metadata is nil")
+	}
+
+	value, exists := m[key]
+	if !exists {
+		return zero, fmt.Errorf("key %q not found", key)
+	}
+
+	typed, ok := value.(T)
+	if !ok {
+		return zero, fmt.Errorf("key %q is not of type %T (got %T)", key, zero, value)
+	}
+
+	return typed, nil
+}
+
+// GetOrDefault is a generic method that returns a default value on error
+func GetOrDefault[T any](m Metadata, key string, defaultValue T) T {
+	val, err := Get[T](m, key)
+	if err != nil {
+		return defaultValue
+	}
+	return val
+}

--- a/internal/entities/metadata_test.go
+++ b/internal/entities/metadata_test.go
@@ -1,0 +1,235 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadata_GetString(t *testing.T) {
+	tests := []struct {
+		name        string
+		metadata    Metadata
+		key         string
+		want        string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "successful retrieval",
+			metadata: Metadata{"sessionType": "dungeon"},
+			key:      "sessionType",
+			want:     "dungeon",
+			wantErr:  false,
+		},
+		{
+			name:        "key not found",
+			metadata:    Metadata{"foo": "bar"},
+			key:         "sessionType",
+			wantErr:     true,
+			errContains: "not found",
+		},
+		{
+			name:        "wrong type",
+			metadata:    Metadata{"sessionType": 123},
+			key:         "sessionType",
+			wantErr:     true,
+			errContains: "is not a string",
+		},
+		{
+			name:        "nil metadata",
+			metadata:    nil,
+			key:         "sessionType",
+			wantErr:     true,
+			errContains: "metadata is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.metadata.GetString(tt.key)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestMetadata_GetStringOrDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadata     Metadata
+		key          string
+		defaultValue string
+		want         string
+	}{
+		{
+			name:         "returns value when exists",
+			metadata:     Metadata{"sessionType": "dungeon"},
+			key:          "sessionType",
+			defaultValue: "combat",
+			want:         "dungeon",
+		},
+		{
+			name:         "returns default when not found",
+			metadata:     Metadata{"foo": "bar"},
+			key:          "sessionType",
+			defaultValue: "combat",
+			want:         "combat",
+		},
+		{
+			name:         "returns default when nil",
+			metadata:     nil,
+			key:          "sessionType",
+			defaultValue: "combat",
+			want:         "combat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.metadata.GetStringOrDefault(tt.key, tt.defaultValue)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMetadata_GetInt(t *testing.T) {
+	tests := []struct {
+		name        string
+		metadata    Metadata
+		key         string
+		want        int
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "int value",
+			metadata: Metadata{"roomNumber": 5},
+			key:      "roomNumber",
+			want:     5,
+			wantErr:  false,
+		},
+		{
+			name:     "float64 value (JSON unmarshaling)",
+			metadata: Metadata{"roomNumber": float64(5)},
+			key:      "roomNumber",
+			want:     5,
+			wantErr:  false,
+		},
+		{
+			name:     "int64 value",
+			metadata: Metadata{"roomNumber": int64(5)},
+			key:      "roomNumber",
+			want:     5,
+			wantErr:  false,
+		},
+		{
+			name:     "string value parseable",
+			metadata: Metadata{"roomNumber": "5"},
+			key:      "roomNumber",
+			want:     5,
+			wantErr:  false,
+		},
+		{
+			name:        "string value not parseable",
+			metadata:    Metadata{"roomNumber": "five"},
+			key:         "roomNumber",
+			wantErr:     true,
+			errContains: "invalid syntax",
+		},
+		{
+			name:        "wrong type",
+			metadata:    Metadata{"roomNumber": true},
+			key:         "roomNumber",
+			wantErr:     true,
+			errContains: "cannot be converted to int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.metadata.GetInt(tt.key)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestMetadata_Generic(t *testing.T) {
+	m := Metadata{
+		"sessionType": "dungeon",
+		"roomNumber":  5,
+		"isActive":    true,
+		"difficulty":  "hard",
+	}
+
+	// Test Get with string
+	sessionType, err := Get[string](m, "sessionType")
+	require.NoError(t, err)
+	assert.Equal(t, "dungeon", sessionType)
+
+	// Test Get with int
+	roomNumber, err := Get[int](m, "roomNumber")
+	require.NoError(t, err)
+	assert.Equal(t, 5, roomNumber)
+
+	// Test Get with bool
+	isActive, err := Get[bool](m, "isActive")
+	require.NoError(t, err)
+	assert.True(t, isActive)
+
+	// Test GetOrDefault
+	difficulty := GetOrDefault(m, "difficulty", "medium")
+	assert.Equal(t, "hard", difficulty)
+
+	// Test GetOrDefault with missing key
+	missing := GetOrDefault(m, "missing", "default")
+	assert.Equal(t, "default", missing)
+
+	// Test type mismatch
+	_, err = Get[int](m, "sessionType")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not of type int")
+}
+
+func TestMetadata_Set(t *testing.T) {
+	m := make(Metadata)
+
+	// Set string
+	m.Set("sessionType", "dungeon")
+	assert.Equal(t, "dungeon", m["sessionType"])
+
+	// Set int
+	m.Set("roomNumber", 5)
+	assert.Equal(t, 5, m["roomNumber"])
+
+	// Set on nil metadata should not panic
+	var nilMetadata Metadata
+	assert.NotPanics(t, func() {
+		nilMetadata.Set("key", "value")
+	})
+}
+
+func TestMetadata_Has(t *testing.T) {
+	m := Metadata{
+		"exists": "value",
+	}
+
+	assert.True(t, m.Has("exists"))
+	assert.False(t, m.Has("notExists"))
+
+	// Test nil metadata
+	var nilMetadata Metadata
+	assert.False(t, nilMetadata.Has("anything"))
+}

--- a/internal/entities/session.go
+++ b/internal/entities/session.go
@@ -38,7 +38,7 @@ type Session struct {
 	Settings          *SessionSettings          `json:"settings"`
 	Encounters        []string                  `json:"encounters"` // List of encounter IDs
 	ActiveEncounterID *string                   `json:"active_encounter_id,omitempty"`
-	Metadata          map[string]interface{}    `json:"metadata,omitempty"` // Custom metadata for the session
+	Metadata          Metadata                  `json:"metadata,omitempty"` // Custom metadata for the session
 	CreatedAt         time.Time                 `json:"created_at"`
 	StartedAt         *time.Time                `json:"started_at"`
 	EndedAt           *time.Time                `json:"ended_at"`
@@ -226,4 +226,45 @@ func (s *Session) IsUserInSession(userID string) bool {
 // UpdateActivity updates the last active timestamp
 func (s *Session) UpdateActivity() {
 	s.LastActive = time.Now()
+}
+
+// IsDungeon checks if this is a dungeon session
+func (s *Session) IsDungeon() bool {
+	if s.Metadata == nil {
+		return false
+	}
+	sessionType := s.Metadata.GetStringOrDefault(string(MetadataKeySessionType), "")
+	return SessionType(sessionType) == SessionTypeDungeon
+}
+
+// GetSessionType returns the session type
+func (s *Session) GetSessionType() SessionType {
+	if s.Metadata == nil {
+		return ""
+	}
+	return SessionType(s.Metadata.GetStringOrDefault(string(MetadataKeySessionType), ""))
+}
+
+// SetSessionType sets the session type
+func (s *Session) SetSessionType(sessionType SessionType) {
+	if s.Metadata == nil {
+		s.Metadata = make(Metadata)
+	}
+	s.Metadata.Set(string(MetadataKeySessionType), string(sessionType))
+}
+
+// GetDifficulty returns the session difficulty
+func (s *Session) GetDifficulty() string {
+	if s.Metadata == nil {
+		return "medium"
+	}
+	return s.Metadata.GetStringOrDefault(string(MetadataKeyDifficulty), "medium")
+}
+
+// GetRoomNumber returns the current room number for dungeon sessions
+func (s *Session) GetRoomNumber() int {
+	if s.Metadata == nil {
+		return 1
+	}
+	return s.Metadata.GetIntOrDefault(string(MetadataKeyRoomNumber), 1)
 }

--- a/internal/entities/session_metadata_test.go
+++ b/internal/entities/session_metadata_test.go
@@ -1,0 +1,170 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSession_IsDungeon(t *testing.T) {
+	tests := []struct {
+		name     string
+		session  *Session
+		expected bool
+	}{
+		{
+			name: "dungeon session",
+			session: &Session{
+				Metadata: Metadata{
+					string(MetadataKeySessionType): string(SessionTypeDungeon),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "combat session",
+			session: &Session{
+				Metadata: Metadata{
+					string(MetadataKeySessionType): string(SessionTypeCombat),
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "nil metadata",
+			session:  &Session{},
+			expected: false,
+		},
+		{
+			name: "empty metadata",
+			session: &Session{
+				Metadata: Metadata{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.session.IsDungeon())
+		})
+	}
+}
+
+func TestSession_GetSetSessionType(t *testing.T) {
+	session := &Session{}
+
+	// Initially empty
+	assert.Equal(t, SessionType(""), session.GetSessionType())
+
+	// Set dungeon type
+	session.SetSessionType(SessionTypeDungeon)
+	assert.Equal(t, SessionTypeDungeon, session.GetSessionType())
+	assert.True(t, session.IsDungeon())
+
+	// Change to combat
+	session.SetSessionType(SessionTypeCombat)
+	assert.Equal(t, SessionTypeCombat, session.GetSessionType())
+	assert.False(t, session.IsDungeon())
+}
+
+func TestSession_GetDifficulty(t *testing.T) {
+	tests := []struct {
+		name     string
+		session  *Session
+		expected string
+	}{
+		{
+			name: "has difficulty",
+			session: &Session{
+				Metadata: Metadata{
+					string(MetadataKeyDifficulty): "hard",
+				},
+			},
+			expected: "hard",
+		},
+		{
+			name:     "nil metadata returns default",
+			session:  &Session{},
+			expected: "medium",
+		},
+		{
+			name: "empty metadata returns default",
+			session: &Session{
+				Metadata: Metadata{},
+			},
+			expected: "medium",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.session.GetDifficulty())
+		})
+	}
+}
+
+func TestSession_GetRoomNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		session  *Session
+		expected int
+	}{
+		{
+			name: "has room number",
+			session: &Session{
+				Metadata: Metadata{
+					string(MetadataKeyRoomNumber): 5,
+				},
+			},
+			expected: 5,
+		},
+		{
+			name: "float64 room number (from JSON)",
+			session: &Session{
+				Metadata: Metadata{
+					string(MetadataKeyRoomNumber): float64(3),
+				},
+			},
+			expected: 3,
+		},
+		{
+			name:     "nil metadata returns default",
+			session:  &Session{},
+			expected: 1,
+		},
+		{
+			name: "empty metadata returns default",
+			session: &Session{
+				Metadata: Metadata{},
+			},
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.session.GetRoomNumber())
+		})
+	}
+}
+
+func TestSessionType_IsValid(t *testing.T) {
+	tests := []struct {
+		sessionType SessionType
+		expected    bool
+	}{
+		{SessionTypeDungeon, true},
+		{SessionTypeCombat, true},
+		{SessionTypeRoleplay, true},
+		{SessionTypeOneShot, true},
+		{SessionType("invalid"), false},
+		{SessionType(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.sessionType), func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.sessionType.IsValid())
+		})
+	}
+}

--- a/internal/entities/session_types.go
+++ b/internal/entities/session_types.go
@@ -1,0 +1,53 @@
+package entities
+
+// SessionType represents the type of game session
+type SessionType string
+
+const (
+	// SessionTypeDungeon represents a dungeon crawl session
+	SessionTypeDungeon SessionType = "dungeon"
+
+	// SessionTypeCombat represents a standard combat encounter
+	SessionTypeCombat SessionType = "combat"
+
+	// SessionTypeRoleplay represents a roleplay-focused session
+	SessionTypeRoleplay SessionType = "roleplay"
+
+	// SessionTypeOneShot represents a one-shot adventure
+	SessionTypeOneShot SessionType = "oneshot"
+)
+
+// String returns the string representation of the session type
+func (st SessionType) String() string {
+	return string(st)
+}
+
+// IsValid checks if the session type is valid
+func (st SessionType) IsValid() bool {
+	switch st {
+	case SessionTypeDungeon, SessionTypeCombat, SessionTypeRoleplay, SessionTypeOneShot:
+		return true
+	default:
+		return false
+	}
+}
+
+// MetadataKeys defines standard metadata keys used across the application
+type MetadataKey string
+
+const (
+	// Session metadata keys
+	MetadataKeySessionType  MetadataKey = "sessionType"
+	MetadataKeyDifficulty   MetadataKey = "difficulty"
+	MetadataKeyRoomNumber   MetadataKey = "roomNumber"
+	MetadataKeyLobbyMessage MetadataKey = "lobbyMessageID"
+	MetadataKeyLobbyChannel MetadataKey = "lobbyChannelID"
+
+	// Character metadata keys
+	MetadataKeyLevel      MetadataKey = "level"
+	MetadataKeyExperience MetadataKey = "experience"
+
+	// Combat metadata keys
+	MetadataKeyInitiative MetadataKey = "initiative"
+	MetadataKeyRound      MetadataKey = "round"
+)

--- a/internal/handlers/discord/dnd/dungeon/enter_room.go
+++ b/internal/handlers/discord/dnd/dungeon/enter_room.go
@@ -103,20 +103,8 @@ func (h *EnterRoomHandler) HandleButton(s *discordgo.Session, i *discordgo.Inter
 
 func (h *EnterRoomHandler) handleCombatRoom(s *discordgo.Session, i *discordgo.InteractionCreate, sess *entities.Session) error {
 	// Get difficulty and room number from session metadata
-	difficulty := "medium"
-	roomNumber := 1
-	if sess.Metadata != nil {
-		if diff, ok := sess.Metadata["difficulty"].(string); ok {
-			difficulty = diff
-		}
-		// Try different type assertions for roomNumber
-		switch roomNum := sess.Metadata["roomNumber"].(type) {
-		case float64:
-			roomNumber = int(roomNum)
-		case int:
-			roomNumber = roomNum
-		}
-	}
+	difficulty := sess.GetDifficulty()
+	roomNumber := sess.GetRoomNumber()
 	fmt.Printf("Combat room - Difficulty: %s, Room Number: %d\n", difficulty, roomNumber)
 
 	// Generate a combat room

--- a/internal/handlers/discord/handler.go
+++ b/internal/handlers/discord/handler.go
@@ -4203,16 +4203,16 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 
 					if freshSess != nil && freshSess.Metadata != nil {
 						// Get stored message ID from session metadata
-						if messageID, ok := freshSess.Metadata["lobbyMessageID"].(string); ok {
-							if channelID, ok := freshSess.Metadata["lobbyChannelID"].(string); ok {
-								log.Printf("Updating dungeon lobby message %s with new party member", messageID)
+						messageID, msgErr := freshSess.Metadata.GetString(string(entities.MetadataKeyLobbyMessage))
+						channelID, chanErr := freshSess.Metadata.GetString(string(entities.MetadataKeyLobbyChannel))
+						if msgErr == nil && chanErr == nil {
+							log.Printf("Updating dungeon lobby message %s with new party member", messageID)
 
-								// Use the helper function to update the lobby message
-								if updateErr := dungeon.UpdateDungeonLobbyMessage(s, h.ServiceProvider.SessionService, h.ServiceProvider.CharacterService, sessionID, messageID, channelID); updateErr != nil {
-									log.Printf("Failed to update dungeon lobby message: %v", updateErr)
-								} else {
-									log.Printf("Successfully updated dungeon lobby with new party member")
-								}
+							// Use the helper function to update the lobby message
+							if updateErr := dungeon.UpdateDungeonLobbyMessage(s, h.ServiceProvider.SessionService, h.ServiceProvider.CharacterService, sessionID, messageID, channelID); updateErr != nil {
+								log.Printf("Failed to update dungeon lobby message: %v", updateErr)
+							} else {
+								log.Printf("Successfully updated dungeon lobby with new party member")
 							}
 						} else {
 							log.Printf("No lobby message ID found in session metadata")

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -248,7 +248,7 @@ func (s *service) CreateEncounter(ctx context.Context, input *CreateEncounterInp
 	member, exists := session.Members[input.UserID]
 	if !exists {
 		// Allow system/bot to create encounters for dungeons
-		if sessionType, ok := session.Metadata["sessionType"].(string); !ok || sessionType != "dungeon" {
+		if !session.IsDungeon() {
 			return nil, dnderr.PermissionDenied("only the DM can create encounters")
 		}
 		// For dungeon sessions, bot/system can create encounters
@@ -339,7 +339,7 @@ func (s *service) AddMonster(ctx context.Context, encounterID, userID string, in
 		member, exists := session.Members[userID]
 		if !exists {
 			// Allow system/bot for dungeon sessions
-			if sessionType, ok := session.Metadata["sessionType"].(string); !ok || sessionType != "dungeon" {
+			if !session.IsDungeon() {
 				return nil, dnderr.PermissionDenied("only the DM can add monsters")
 			}
 		} else if member.Role != entities.SessionRoleDM {
@@ -495,7 +495,7 @@ func (s *service) RollInitiative(ctx context.Context, encounterID, userID string
 		if err != nil {
 			return dnderr.Wrap(err, "failed to get session")
 		}
-		if sessionType, ok := session.Metadata["sessionType"].(string); !ok || sessionType != "dungeon" {
+		if !session.IsDungeon() {
 			return dnderr.PermissionDenied("only the DM can roll initiative")
 		}
 	}
@@ -575,7 +575,7 @@ func (s *service) StartEncounter(ctx context.Context, encounterID, userID string
 		if err != nil {
 			return dnderr.Wrap(err, "failed to get session")
 		}
-		if sessionType, ok := session.Metadata["sessionType"].(string); !ok || sessionType != "dungeon" {
+		if !session.IsDungeon() {
 			return dnderr.PermissionDenied("only the DM can start the encounter")
 		}
 	}


### PR DESCRIPTION
## Problem
Throughout the codebase, we have fragile type assertions when accessing session metadata:
```go
if sessionType, ok := session.Metadata["sessionType"].(string); ok && sessionType == "dungeon" {
    // Handle dungeon
}
```

This pattern is:
- Error-prone
- Verbose
- Scattered throughout the codebase
- Prone to runtime panics

## Solution
This PR introduces a comprehensive type-safe metadata system with:

### 1. Metadata Type with Safe Accessors
```go
// Type-specific getters
str, err := metadata.GetString("key")
num, err := metadata.GetInt("key")
bool, err := metadata.GetBool("key")

// With defaults
str := metadata.GetStringOrDefault("key", "default")
```

### 2. Generic Type-Safe Access
```go
// Generic getter
sessionType, err := entities.Get[string](metadata, "sessionType")

// With default
difficulty := entities.GetOrDefault(metadata, "difficulty", "medium")
```

### 3. Session Helper Methods
```go
// Clean, readable checks
if session.IsDungeon() {
    // Handle dungeon
}

// Type-safe getters
difficulty := session.GetDifficulty()
roomNumber := session.GetRoomNumber()
```

### 4. Type Constants
```go
const (
    SessionTypeDungeon  SessionType = "dungeon"
    SessionTypeCombat   SessionType = "combat"
    // ...
)

const (
    MetadataKeySessionType  MetadataKey = "sessionType"
    MetadataKeyDifficulty   MetadataKey = "difficulty"
    // ...
)
```

## Changes
- Created `Metadata` type with safe accessor methods
- Added generic `Get[T]` and `GetOrDefault[T]` functions
- Added `SessionType` constants and validation
- Added `MetadataKey` constants for consistent keys
- Updated `Session` entity with helper methods
- Refactored all metadata access throughout codebase
- Added comprehensive tests
- Added architecture improvement issue template
- Added documentation

## Benefits
- ✅ Type safety - no more runtime panics from bad casts
- ✅ Cleaner code - reduced boilerplate
- ✅ Better defaults - built-in default handling
- ✅ Consistency - standard patterns everywhere
- ✅ Discoverability - constants make keys easy to find
- ✅ Maintainability - easier to refactor and extend

## Testing
- Added comprehensive unit tests for all metadata methods
- All existing tests pass
- No breaking changes to external APIs

## Documentation
See `docs/architecture/metadata-refactoring.md` for detailed examples and migration guide.

This is the kind of architectural improvement that makes building features easier and more reliable!