### PR TITLE
Implement Ranger class feature selection during character creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,19 +93,32 @@ jobs:
         export PATH=$PATH:$(go env GOPATH)/bin
         go generate ./...
 
-    - name: Run unit tests (minimal - build issues being fixed)
+    - name: Run unit tests
       run: |
-        echo "### Running minimal test suite" >> $GITHUB_STEP_SUMMARY
-        echo "Note: Full test suite temporarily disabled due to build issues" >> $GITHUB_STEP_SUMMARY
+        echo "### Running full test suite" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         
-        # Only test packages that can build
-        go test ./internal/entities -run="TestAbilityBonus|TestAbilityScore" -v -short || echo "entities tests skipped"
-        go test ./internal/repositories/characters -v -short || echo "repositories tests skipped"
-        go test ./internal/dice/... -v -short 2>/dev/null || echo "dice tests skipped"
-        go test ./internal/utils/... -v -short 2>/dev/null || echo "utils tests skipped"
+        # Run all tests with race detector
+        go test ./... -v -short -race | tee test_output.txt
+        
+        # Capture exit code
+        TEST_EXIT_CODE=${PIPESTATUS[0]}
         
         echo '```' >> $GITHUB_STEP_SUMMARY
+        
+        # Add test summary
+        if [ $TEST_EXIT_CODE -eq 0 ]; then
+          echo "✅ All tests passed!" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ Some tests failed!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Failed tests:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -E "^--- FAIL:|FAIL\s+github.com" test_output.txt >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+        fi
+        
+        exit $TEST_EXIT_CODE
 
     # Integration tests temporarily disabled
     # - name: Run integration tests

--- a/internal/effects/manager_test.go
+++ b/internal/effects/manager_test.go
@@ -48,7 +48,7 @@ func TestManager_AddEffect(t *testing.T) {
 			Source:       SourceAbility,
 			StackingRule: StackingReplace,
 		}
-		_ = replaceManager.AddEffect(effect1)
+		require.NoError(t, replaceManager.AddEffect(effect1))
 
 		// Add second effect with same name and source
 		effect2 := &StatusEffect{
@@ -57,7 +57,7 @@ func TestManager_AddEffect(t *testing.T) {
 			Source:       SourceAbility,
 			StackingRule: StackingReplace,
 		}
-		_ = replaceManager.AddEffect(effect2)
+		require.NoError(t, replaceManager.AddEffect(effect2))
 
 		active := replaceManager.GetActiveEffects()
 		assert.Len(t, active, 1)
@@ -75,7 +75,7 @@ func TestManager_AddEffect(t *testing.T) {
 				Source:       SourceSpell,
 				StackingRule: StackingStack,
 			}
-			_ = manager.AddEffect(effect)
+			require.NoError(t, manager.AddEffect(effect))
 		}
 
 		active := manager.GetActiveEffects()
@@ -91,7 +91,7 @@ func TestManager_RemoveEffect(t *testing.T) {
 		Name:   "Test Effect",
 		Source: SourceAbility,
 	}
-	_ = manager.AddEffect(effect)
+	require.NoError(t, manager.AddEffect(effect))
 
 	manager.RemoveEffect("test_effect")
 	active := manager.GetActiveEffects()
@@ -108,7 +108,7 @@ func TestManager_RemoveEffectsBySource(t *testing.T) {
 		Source:   SourceSpell,
 		SourceID: "bless_spell",
 	}
-	_ = manager.AddEffect(spellEffect)
+	require.NoError(t, manager.AddEffect(spellEffect))
 
 	abilityEffect := &StatusEffect{
 		ID:       "ability_1",
@@ -116,7 +116,7 @@ func TestManager_RemoveEffectsBySource(t *testing.T) {
 		Source:   SourceAbility,
 		SourceID: "barbarian_rage",
 	}
-	_ = manager.AddEffect(abilityEffect)
+	require.NoError(t, manager.AddEffect(abilityEffect))
 
 	// Remove all spell effects
 	manager.RemoveEffectsBySource(SourceSpell, "bless_spell")
@@ -131,7 +131,7 @@ func TestManager_GetModifiers(t *testing.T) {
 
 	t.Run("gets modifiers for target", func(t *testing.T) {
 		effect := BuildRageEffect(1)
-		_ = manager.AddEffect(effect)
+		require.NoError(t, manager.AddEffect(effect))
 
 		// Get damage modifiers
 		modifiers := manager.GetModifiers(TargetDamage, map[string]string{
@@ -144,7 +144,7 @@ func TestManager_GetModifiers(t *testing.T) {
 
 	t.Run("respects modifier conditions", func(t *testing.T) {
 		effect := BuildRageEffect(1)
-		_ = manager.AddEffect(effect)
+		require.NoError(t, manager.AddEffect(effect))
 
 		// Get damage modifiers for ranged attack (should not apply)
 		modifiers := manager.GetModifiers(TargetDamage, map[string]string{
@@ -156,7 +156,7 @@ func TestManager_GetModifiers(t *testing.T) {
 
 	t.Run("respects effect conditions", func(t *testing.T) {
 		effect := BuildFavoredEnemyEffect("orc")
-		_ = manager.AddEffect(effect)
+		require.NoError(t, manager.AddEffect(effect))
 
 		// Get modifiers when fighting an orc
 		modifiers := manager.GetModifiers(TargetSkillCheck, map[string]string{
@@ -181,7 +181,7 @@ func TestManager_Expiration(t *testing.T) {
 			Name:     "Instant Effect",
 			Duration: Duration{Type: DurationInstant},
 		}
-		_ = manager.AddEffect(effect)
+		require.NoError(t, manager.AddEffect(effect))
 
 		// Sleep to ensure time passes
 		time.Sleep(10 * time.Millisecond)
@@ -196,7 +196,7 @@ func TestManager_Expiration(t *testing.T) {
 			Name:     "Permanent Effect",
 			Duration: Duration{Type: DurationPermanent},
 		}
-		_ = manager.AddEffect(effect)
+		require.NoError(t, manager.AddEffect(effect))
 
 		active := manager.GetActiveEffects()
 		assert.Len(t, active, 1)
@@ -208,11 +208,11 @@ func TestManager_ClearConcentration(t *testing.T) {
 
 	// Add concentration effect
 	concentrationEffect := BuildBlessEffect()
-	_ = manager.AddEffect(concentrationEffect)
+	require.NoError(t, manager.AddEffect(concentrationEffect))
 
 	// Add non-concentration effect
 	normalEffect := BuildRageEffect(1)
-	_ = manager.AddEffect(normalEffect)
+	require.NoError(t, manager.AddEffect(normalEffect))
 
 	// Clear concentration
 	manager.ClearConcentration()

--- a/internal/entities/character.go
+++ b/internal/entities/character.go
@@ -1283,8 +1283,17 @@ func (c *Character) syncResourcestoEffectManager() {
 				log.Printf("Failed to add rage effect: %v", err)
 			}
 		} else if oldEffect.Name == "Favored Enemy" && oldEffect.Source == string(effects.SourceFeature) {
-			// Rebuild favored enemy effect
-			favoredEnemyEffect := effects.BuildFavoredEnemyEffect("orc") // TODO: Store enemy type
+			// Rebuild favored enemy effect with the selected enemy type
+			enemyType := "humanoids" // default fallback
+			for _, feature := range c.Features {
+				if feature.Key == "favored_enemy" && feature.Metadata != nil {
+					if et, ok := feature.Metadata["enemy_type"].(string); ok {
+						enemyType = et
+						break
+					}
+				}
+			}
+			favoredEnemyEffect := effects.BuildFavoredEnemyEffect(enemyType)
 			favoredEnemyEffect.ID = oldEffect.ID
 			if err := c.EffectManager.AddEffect(favoredEnemyEffect); err != nil {
 				log.Printf("Failed to add favored enemy effect: %v", err)

--- a/internal/entities/character_ranger_test.go
+++ b/internal/entities/character_ranger_test.go
@@ -28,6 +28,16 @@ func TestCharacter_RangerInitialization(t *testing.T) {
 		},
 		MaxHitPoints:     11, // d10 + 1 CON
 		CurrentHitPoints: 11,
+		Features: []*CharacterFeature{
+			{
+				Key:  "favored_enemy",
+				Name: "Favored Enemy",
+				Type: FeatureTypeClass,
+				Metadata: map[string]any{
+					"enemy_type": "orc",
+				},
+			},
+		},
 	}
 
 	// Initialize resources which should add ranger status effects
@@ -106,6 +116,16 @@ func TestCharacter_RangerMultipleEffects(t *testing.T) {
 		Class: &Class{
 			Key:  "ranger",
 			Name: "Ranger",
+		},
+		Features: []*CharacterFeature{
+			{
+				Key:  "favored_enemy",
+				Name: "Favored Enemy",
+				Type: FeatureTypeClass,
+				Metadata: map[string]any{
+					"enemy_type": "undead",
+				},
+			},
 		},
 	}
 

--- a/internal/entities/feature.go
+++ b/internal/entities/feature.go
@@ -12,10 +12,11 @@ const (
 
 // CharacterFeature represents a character feature (trait, ability, etc)
 type CharacterFeature struct {
-	Key         string      `json:"key"`
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
-	Type        FeatureType `json:"type"`
-	Level       int         `json:"level"`  // Level when gained (0 for racial)
-	Source      string      `json:"source"` // Race/Class/Subclass name
+	Key         string         `json:"key"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Type        FeatureType    `json:"type"`
+	Level       int            `json:"level"`              // Level when gained (0 for racial)
+	Source      string         `json:"source"`             // Race/Class/Subclass name
+	Metadata    map[string]any `json:"metadata,omitempty"` // For storing selections like favored enemy type
 }

--- a/internal/handlers/discord/combat/helpers.go
+++ b/internal/handlers/discord/combat/helpers.go
@@ -15,7 +15,10 @@ func parseCustomID(customID string) []string {
 
 // isEphemeralInteraction checks if an interaction originated from an ephemeral message
 func isEphemeralInteraction(i *discordgo.InteractionCreate) bool {
-	return i.Message != nil && i.Message.Flags&discordgo.MessageFlagsEphemeral != 0
+	if i == nil || i.Interaction == nil || i.Message == nil {
+		return false
+	}
+	return i.Message.Flags&discordgo.MessageFlagsEphemeral != 0
 }
 
 // respondError sends an error response

--- a/internal/handlers/discord/dnd/character/class_features.go
+++ b/internal/handlers/discord/dnd/character/class_features.go
@@ -146,6 +146,17 @@ func (h *ClassFeaturesHandler) ShowFavoredEnemySelection(req *InteractionRequest
 		},
 	}
 
+	// Add progress field
+	classKey := ""
+	if char.Class != nil {
+		classKey = char.Class.Key
+	}
+	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+		Name:   "Progress",
+		Value:  BuildProgressValue(classKey, "class_features"),
+		Inline: false,
+	})
+
 	// Create components
 	components := []discordgo.MessageComponent{
 		discordgo.ActionsRow{
@@ -159,12 +170,15 @@ func (h *ClassFeaturesHandler) ShowFavoredEnemySelection(req *InteractionRequest
 		},
 	}
 
-	// Update the interaction
-	_, err = req.Session.InteractionResponseEdit(req.Interaction.Interaction, &discordgo.WebhookEdit{
-		Embeds:     &[]*discordgo.MessageEmbed{embed},
-		Components: &components,
+	// Update the interaction response
+	return req.Session.InteractionRespond(req.Interaction.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Embeds:     []*discordgo.MessageEmbed{embed},
+			Components: components,
+			Flags:      discordgo.MessageFlagsEphemeral,
+		},
 	})
-	return err
 }
 
 // ShowNaturalExplorerSelection displays the natural explorer terrain selection UI
@@ -201,6 +215,17 @@ func (h *ClassFeaturesHandler) ShowNaturalExplorerSelection(req *InteractionRequ
 		},
 	}
 
+	// Add progress field
+	classKey := ""
+	if char.Class != nil {
+		classKey = char.Class.Key
+	}
+	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+		Name:   "Progress",
+		Value:  BuildProgressValue(classKey, "class_features"),
+		Inline: false,
+	})
+
 	// Create components
 	components := []discordgo.MessageComponent{
 		discordgo.ActionsRow{
@@ -214,12 +239,15 @@ func (h *ClassFeaturesHandler) ShowNaturalExplorerSelection(req *InteractionRequ
 		},
 	}
 
-	// Update the interaction
-	_, err = req.Session.InteractionResponseEdit(req.Interaction.Interaction, &discordgo.WebhookEdit{
-		Embeds:     &[]*discordgo.MessageEmbed{embed},
-		Components: &components,
+	// Update the interaction response
+	return req.Session.InteractionRespond(req.Interaction.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Embeds:     []*discordgo.MessageEmbed{embed},
+			Components: components,
+			Flags:      discordgo.MessageFlagsEphemeral,
+		},
 	})
-	return err
 }
 
 // ShouldShowClassFeatures checks if a character needs to select class features

--- a/internal/handlers/discord/dnd/character/class_features.go
+++ b/internal/handlers/discord/dnd/character/class_features.go
@@ -1,0 +1,259 @@
+package character
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/services/character"
+	"github.com/bwmarrin/discordgo"
+)
+
+// ClassFeaturesHandler handles class-specific feature selections during character creation
+type ClassFeaturesHandler struct {
+	characterService character.Service
+}
+
+// NewClassFeaturesHandler creates a new class features handler
+func NewClassFeaturesHandler(characterService character.Service) *ClassFeaturesHandler {
+	return &ClassFeaturesHandler{
+		characterService: characterService,
+	}
+}
+
+// ClassFeaturesRequest contains data for class feature selection
+type ClassFeaturesRequest struct {
+	Session     *discordgo.Session
+	Interaction *discordgo.InteractionCreate
+	CharacterID string
+	FeatureType string // e.g., "favored_enemy", "divine_domain"
+	Selection   string // The selected option
+}
+
+// Handle processes class feature selections
+func (h *ClassFeaturesHandler) Handle(req *ClassFeaturesRequest) error {
+	// Get the character
+	char, err := h.characterService.GetByID(req.CharacterID)
+	if err != nil {
+		return fmt.Errorf("failed to get character: %w", err)
+	}
+
+	// Store the selection based on feature type
+	switch req.FeatureType {
+	case "favored_enemy":
+		err = h.handleFavoredEnemy(req, char)
+	case "natural_explorer":
+		err = h.handleNaturalExplorer(req, char)
+	// Add other class features here (divine_domain, fighting_style, etc.)
+	default:
+		err = fmt.Errorf("unknown feature type: %s", req.FeatureType)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// Save the character (using UpdateEquipment which saves the whole character)
+	if err := h.characterService.UpdateEquipment(char); err != nil {
+		return fmt.Errorf("failed to update character: %w", err)
+	}
+
+	return nil
+}
+
+// handleFavoredEnemy stores the ranger's favored enemy selection
+func (h *ClassFeaturesHandler) handleFavoredEnemy(req *ClassFeaturesRequest, char *entities.Character) error {
+	// Find the favored enemy feature and update its metadata
+	for _, feature := range char.Features {
+		if feature.Key == "favored_enemy" {
+			if feature.Metadata == nil {
+				feature.Metadata = make(map[string]any)
+			}
+			feature.Metadata["enemy_type"] = req.Selection
+
+			// Log for debugging
+			log.Printf("Set favored enemy for %s to %s", char.Name, req.Selection)
+			break
+		}
+	}
+
+	return nil
+}
+
+// handleNaturalExplorer stores the ranger's natural explorer terrain selection
+func (h *ClassFeaturesHandler) handleNaturalExplorer(req *ClassFeaturesRequest, char *entities.Character) error {
+	// Find the natural explorer feature and update its metadata
+	for _, feature := range char.Features {
+		if feature.Key == "natural_explorer" {
+			if feature.Metadata == nil {
+				feature.Metadata = make(map[string]any)
+			}
+			feature.Metadata["terrain_type"] = req.Selection
+
+			// Log for debugging
+			log.Printf("Set natural explorer terrain for %s to %s", char.Name, req.Selection)
+			break
+		}
+	}
+
+	return nil
+}
+
+// InteractionRequest contains basic interaction data
+type InteractionRequest struct {
+	Session     *discordgo.Session
+	Interaction *discordgo.InteractionCreate
+	CharacterID string
+}
+
+// ShowFavoredEnemySelection displays the favored enemy selection UI
+func (h *ClassFeaturesHandler) ShowFavoredEnemySelection(req *InteractionRequest) error {
+	// Get the character
+	char, err := h.characterService.GetByID(req.CharacterID)
+	if err != nil {
+		return fmt.Errorf("failed to get character: %w", err)
+	}
+
+	// Enemy type options
+	enemyOptions := []discordgo.SelectMenuOption{
+		{Label: "Aberrations", Value: "aberrations", Description: "Beholders, mind flayers, etc."},
+		{Label: "Beasts", Value: "beasts", Description: "Bears, wolves, dire animals"},
+		{Label: "Celestials", Value: "celestials", Description: "Angels, pegasi, unicorns"},
+		{Label: "Constructs", Value: "constructs", Description: "Golems, animated objects"},
+		{Label: "Dragons", Value: "dragons", Description: "True dragons and dragonkin"},
+		{Label: "Elementals", Value: "elementals", Description: "Creatures from elemental planes"},
+		{Label: "Fey", Value: "fey", Description: "Sprites, dryads, pixies"},
+		{Label: "Fiends", Value: "fiends", Description: "Devils, demons, yugoloths"},
+		{Label: "Giants", Value: "giants", Description: "Hill giants, storm giants, ogres"},
+		{Label: "Monstrosities", Value: "monstrosities", Description: "Griffons, hydras, owlbears"},
+		{Label: "Oozes", Value: "oozes", Description: "Black puddings, gelatinous cubes"},
+		{Label: "Plants", Value: "plants", Description: "Shambling mounds, treants"},
+		{Label: "Undead", Value: "undead", Description: "Zombies, skeletons, vampires"},
+		{Label: "Two Humanoid Races", Value: "humanoids", Description: "Orcs & goblins, elves & dwarves, etc."},
+	}
+
+	// Create embed
+	embed := &discordgo.MessageEmbed{
+		Title:       "Choose Your Favored Enemy",
+		Description: fmt.Sprintf("**%s**, as a Ranger you have studied a specific type of enemy extensively.\n\nYou gain advantage on Wisdom (Survival) checks to track them and Intelligence checks to recall information about them.", char.Name),
+		Color:       0x228B22, // Forest Green
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "Your Selection",
+				Value:  "Choose the type of creature you have dedicated yourself to hunting.",
+				Inline: false,
+			},
+		},
+	}
+
+	// Create components
+	components := []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					CustomID:    fmt.Sprintf("character_create:class_features:%s:favored_enemy", char.ID),
+					Placeholder: "Select your favored enemy...",
+					Options:     enemyOptions,
+				},
+			},
+		},
+	}
+
+	// Update the interaction
+	_, err = req.Session.InteractionResponseEdit(req.Interaction.Interaction, &discordgo.WebhookEdit{
+		Embeds:     &[]*discordgo.MessageEmbed{embed},
+		Components: &components,
+	})
+	return err
+}
+
+// ShowNaturalExplorerSelection displays the natural explorer terrain selection UI
+func (h *ClassFeaturesHandler) ShowNaturalExplorerSelection(req *InteractionRequest) error {
+	// Get the character
+	char, err := h.characterService.GetByID(req.CharacterID)
+	if err != nil {
+		return fmt.Errorf("failed to get character: %w", err)
+	}
+
+	// Terrain options
+	terrainOptions := []discordgo.SelectMenuOption{
+		{Label: "Arctic", Value: "arctic", Description: "Frozen tundra and icy wastes"},
+		{Label: "Coast", Value: "coast", Description: "Beaches, cliffs, and shores"},
+		{Label: "Desert", Value: "desert", Description: "Sandy and rocky badlands"},
+		{Label: "Forest", Value: "forest", Description: "Woodlands and jungles"},
+		{Label: "Grassland", Value: "grassland", Description: "Plains, savannas, and meadows"},
+		{Label: "Mountain", Value: "mountain", Description: "Hills and peaks"},
+		{Label: "Swamp", Value: "swamp", Description: "Marshes, bogs, and fens"},
+		{Label: "Underdark", Value: "underdark", Description: "Caves and underground"},
+	}
+
+	// Create embed
+	embed := &discordgo.MessageEmbed{
+		Title:       "Choose Your Favored Terrain",
+		Description: fmt.Sprintf("**%s**, you are particularly familiar with one type of natural environment.\n\nWhile in your favored terrain:\n• Your group can't become lost except by magical means\n• You remain alert while tracking, foraging, or navigating\n• You can move stealthily at normal pace when alone\n• You find food and water for up to 6 people daily", char.Name),
+		Color:       0x228B22, // Forest Green
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "Your Selection",
+				Value:  "Choose the terrain where you feel most at home.",
+				Inline: false,
+			},
+		},
+	}
+
+	// Create components
+	components := []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					CustomID:    fmt.Sprintf("character_create:class_features:%s:natural_explorer", char.ID),
+					Placeholder: "Select your favored terrain...",
+					Options:     terrainOptions,
+				},
+			},
+		},
+	}
+
+	// Update the interaction
+	_, err = req.Session.InteractionResponseEdit(req.Interaction.Interaction, &discordgo.WebhookEdit{
+		Embeds:     &[]*discordgo.MessageEmbed{embed},
+		Components: &components,
+	})
+	return err
+}
+
+// ShouldShowClassFeatures checks if a character needs to select class features
+func (h *ClassFeaturesHandler) ShouldShowClassFeatures(char *entities.Character) (needsSelection bool, featureType string) {
+	if char.Class == nil {
+		return false, ""
+	}
+
+	// Check each class for required selections
+	switch char.Class.Key {
+	case "ranger":
+		// Check if ranger has selected favored enemy
+		for _, feature := range char.Features {
+			if feature.Key == "favored_enemy" {
+				if feature.Metadata == nil || feature.Metadata["enemy_type"] == nil {
+					return true, "favored_enemy"
+				}
+			}
+			if feature.Key == "natural_explorer" {
+				if feature.Metadata == nil || feature.Metadata["terrain_type"] == nil {
+					return true, "natural_explorer"
+				}
+			}
+		}
+	// Add other classes with level 1 choices here
+	case "cleric":
+		// TODO: Check for divine domain selection
+	case "fighter":
+		// TODO: Check for fighting style selection
+	case "warlock":
+		// TODO: Check for patron selection
+	case "sorcerer":
+		// TODO: Check for sorcerous origin selection
+	}
+
+	return false, ""
+}

--- a/internal/handlers/discord/dnd/character/class_features_test.go
+++ b/internal/handlers/discord/dnd/character/class_features_test.go
@@ -1,0 +1,107 @@
+package character
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	mockchar "github.com/KirkDiggler/dnd-bot-discord/internal/services/character/mock"
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestClassFeaturesHandler_HandleFavoredEnemy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mockchar.NewMockService(ctrl)
+	handler := NewClassFeaturesHandler(mockService)
+
+	// Create a test ranger character
+	char := &entities.Character{
+		ID:   "test-ranger",
+		Name: "Test Ranger",
+		Class: &entities.Class{
+			Key:  "ranger",
+			Name: "Ranger",
+		},
+		Features: []*entities.CharacterFeature{
+			{
+				Key:      "favored_enemy",
+				Name:     "Favored Enemy",
+				Type:     entities.FeatureTypeClass,
+				Source:   "Ranger",
+				Metadata: nil,
+			},
+		},
+	}
+
+	// Mock the service calls
+	mockService.EXPECT().GetByID("test-ranger").Return(char, nil)
+	mockService.EXPECT().UpdateEquipment(char).Return(nil)
+
+	// Create a test request
+	req := &ClassFeaturesRequest{
+		Session:     &discordgo.Session{},
+		Interaction: &discordgo.InteractionCreate{},
+		CharacterID: "test-ranger",
+		FeatureType: "favored_enemy",
+		Selection:   "orcs",
+	}
+
+	// Handle the request
+	err := handler.Handle(req)
+	assert.NoError(t, err)
+
+	// Verify the favored enemy was set
+	assert.NotNil(t, char.Features[0].Metadata)
+	assert.Equal(t, "orcs", char.Features[0].Metadata["enemy_type"])
+}
+
+func TestClassFeaturesHandler_HandleNaturalExplorer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockService := mockchar.NewMockService(ctrl)
+	handler := NewClassFeaturesHandler(mockService)
+
+	// Create a test ranger character
+	char := &entities.Character{
+		ID:   "test-ranger",
+		Name: "Test Ranger",
+		Class: &entities.Class{
+			Key:  "ranger",
+			Name: "Ranger",
+		},
+		Features: []*entities.CharacterFeature{
+			{
+				Key:      "natural_explorer",
+				Name:     "Natural Explorer",
+				Type:     entities.FeatureTypeClass,
+				Source:   "Ranger",
+				Metadata: nil,
+			},
+		},
+	}
+
+	// Mock the service calls
+	mockService.EXPECT().GetByID("test-ranger").Return(char, nil)
+	mockService.EXPECT().UpdateEquipment(char).Return(nil)
+
+	// Create a test request
+	req := &ClassFeaturesRequest{
+		Session:     &discordgo.Session{},
+		Interaction: &discordgo.InteractionCreate{},
+		CharacterID: "test-ranger",
+		FeatureType: "natural_explorer",
+		Selection:   "forest",
+	}
+
+	// Handle the request
+	err := handler.Handle(req)
+	assert.NoError(t, err)
+
+	// Verify the natural explorer terrain was set
+	assert.NotNil(t, char.Features[0].Metadata)
+	assert.Equal(t, "forest", char.Features[0].Metadata["terrain_type"])
+}

--- a/internal/handlers/discord/dnd/character/proficiency_choices.go
+++ b/internal/handlers/discord/dnd/character/proficiency_choices.go
@@ -163,7 +163,7 @@ func (h *ProficiencyChoicesHandler) Handle(req *ProficiencyChoicesRequest) error
 	// Progress
 	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 		Name:   "Progress",
-		Value:  "✅ Step 1: Race\n✅ Step 2: Class\n✅ Step 3: Abilities\n⏳ Step 4: Proficiencies\n⏳ Step 5: Details",
+		Value:  BuildProgressValue(req.ClassKey, "proficiencies"),
 		Inline: false,
 	})
 

--- a/internal/handlers/discord/dnd/character/progress.go
+++ b/internal/handlers/discord/dnd/character/progress.go
@@ -26,7 +26,7 @@ func BuildProgressValue(classKey, currentStep string) string {
 		featureStepName := fmt.Sprintf("Step %d: Class Features", nextStep)
 		steps = append(steps, ProgressStep{
 			Name:      featureStepName,
-			Completed: currentStep != "class_features" && currentStep != "abilities",
+			Completed: isClassFeaturesStepCompleted(currentStep),
 		})
 		nextStep++
 	}
@@ -68,4 +68,11 @@ func needsClassFeatures(classKey string) bool {
 	default:
 		return false
 	}
+}
+
+// isClassFeaturesStepCompleted returns true if the class features step is completed
+func isClassFeaturesStepCompleted(currentStep string) bool {
+	// Class features are completed if we're past that step
+	// (i.e., not currently on "class_features" or "abilities")
+	return currentStep != "class_features" && currentStep != "abilities"
 }

--- a/internal/handlers/discord/dnd/character/progress.go
+++ b/internal/handlers/discord/dnd/character/progress.go
@@ -1,0 +1,71 @@
+package character
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProgressStep represents a step in character creation
+type ProgressStep struct {
+	Name      string
+	Completed bool
+}
+
+// BuildProgressValue creates a progress field value for character creation
+// It dynamically adjusts based on the character's class
+func BuildProgressValue(classKey, currentStep string) string {
+	steps := []ProgressStep{
+		{Name: "Step 1: Race", Completed: true},
+		{Name: "Step 2: Class", Completed: true},
+		{Name: "Step 3: Abilities", Completed: true},
+	}
+
+	// Add class features step for classes that need it
+	nextStep := 4
+	if needsClassFeatures(classKey) {
+		featureStepName := fmt.Sprintf("Step %d: Class Features", nextStep)
+		steps = append(steps, ProgressStep{
+			Name:      featureStepName,
+			Completed: currentStep != "class_features" && currentStep != "abilities",
+		})
+		nextStep++
+	}
+
+	// Add remaining steps
+	steps = append(steps,
+		ProgressStep{
+			Name:      fmt.Sprintf("Step %d: Proficiencies", nextStep),
+			Completed: currentStep == "equipment" || currentStep == "details",
+		},
+		ProgressStep{
+			Name:      fmt.Sprintf("Step %d: Equipment", nextStep+1),
+			Completed: currentStep == "details",
+		},
+		ProgressStep{
+			Name:      fmt.Sprintf("Step %d: Details", nextStep+2),
+			Completed: false,
+		},
+	)
+
+	// Build the progress string
+	var progressLines []string
+	for _, step := range steps {
+		icon := "⏳"
+		if step.Completed {
+			icon = "✅"
+		}
+		progressLines = append(progressLines, fmt.Sprintf("%s %s", icon, step.Name))
+	}
+
+	return strings.Join(progressLines, "\n")
+}
+
+// needsClassFeatures returns true if the class requires feature selection at level 1
+func needsClassFeatures(classKey string) bool {
+	switch classKey {
+	case "ranger", "cleric", "warlock", "fighter", "sorcerer":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/handlers/discord/dnd/character/sheet.go
+++ b/internal/handlers/discord/dnd/character/sheet.go
@@ -10,6 +10,8 @@ import (
 	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/utils"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/services"
 	"github.com/bwmarrin/discordgo"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // SheetHandler handles the character sheet display command
@@ -284,8 +286,27 @@ func buildFeatureSummary(char *entities.Character) []string {
 	// Add class features
 	if len(classFeatures) > 0 {
 		lines = append(lines, "**Class Features:**")
+		caser := cases.Title(language.English)
 		for _, feat := range classFeatures {
-			lines = append(lines, fmt.Sprintf("• %s", feat.Name))
+			featName := feat.Name
+			// Add specific selections from metadata
+			if feat.Key == "favored_enemy" && feat.Metadata != nil {
+				if enemyType, ok := feat.Metadata["enemy_type"].(string); ok {
+					// Capitalize the enemy type for display
+					enemyDisplay := caser.String(enemyType)
+					if enemyType == "humanoids" {
+						enemyDisplay = "Two Humanoid Races"
+					}
+					featName = fmt.Sprintf("%s (%s)", feat.Name, enemyDisplay)
+				}
+			} else if feat.Key == "natural_explorer" && feat.Metadata != nil {
+				if terrainType, ok := feat.Metadata["terrain_type"].(string); ok {
+					// Capitalize the terrain type
+					terrainDisplay := caser.String(terrainType)
+					featName = fmt.Sprintf("%s (%s)", feat.Name, terrainDisplay)
+				}
+			}
+			lines = append(lines, fmt.Sprintf("• %s", featName))
 		}
 	}
 

--- a/internal/handlers/discord/dnd/character/sheet_effects_test.go
+++ b/internal/handlers/discord/dnd/character/sheet_effects_test.go
@@ -51,6 +51,16 @@ func TestBuildActiveEffectsDisplay(t *testing.T) {
 			Name:  "Legolas",
 			Level: 1,
 			Class: &entities.Class{Key: "ranger"},
+			Features: []*entities.CharacterFeature{
+				{
+					Key:  "favored_enemy",
+					Name: "Favored Enemy",
+					Type: entities.FeatureTypeClass,
+					Metadata: map[string]any{
+						"enemy_type": "orc",
+					},
+				},
+			},
 		}
 
 		// Initialize resources - this should add the favored enemy effect

--- a/internal/handlers/discord/dnd/character/sheet_ranger_test.go
+++ b/internal/handlers/discord/dnd/character/sheet_ranger_test.go
@@ -1,0 +1,123 @@
+package character
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+)
+
+func TestBuildFeatureSummary_RangerWithSelections(t *testing.T) {
+	// Create a ranger character with favored enemy and natural explorer selections
+	ranger := &entities.Character{
+		Name:  "Test Ranger",
+		Level: 1,
+		Features: []*entities.CharacterFeature{
+			{
+				Key:         "favored_enemy",
+				Name:        "Favored Enemy",
+				Type:        entities.FeatureTypeClass,
+				Description: "You have significant experience studying, tracking, hunting, and even talking to a certain type of enemy.",
+				Metadata: map[string]any{
+					"enemy_type": "undead",
+				},
+			},
+			{
+				Key:         "natural_explorer",
+				Name:        "Natural Explorer",
+				Type:        entities.FeatureTypeClass,
+				Description: "You are particularly familiar with one type of natural environment and are adept at traveling and surviving in such regions.",
+				Metadata: map[string]any{
+					"terrain_type": "forest",
+				},
+			},
+		},
+	}
+
+	lines := buildFeatureSummary(ranger)
+
+	// Check that the features show the selected values
+	foundFavoredEnemy := false
+	foundNaturalExplorer := false
+
+	for _, line := range lines {
+		if strings.Contains(line, "Favored Enemy (Undead)") {
+			foundFavoredEnemy = true
+		}
+		if strings.Contains(line, "Natural Explorer (Forest)") {
+			foundNaturalExplorer = true
+		}
+	}
+
+	if !foundFavoredEnemy {
+		t.Errorf("Expected to find 'Favored Enemy (Undead)' in feature summary, got: %v", lines)
+	}
+
+	if !foundNaturalExplorer {
+		t.Errorf("Expected to find 'Natural Explorer (forest)' in feature summary, got: %v", lines)
+	}
+}
+
+func TestBuildFeatureSummary_RangerWithoutSelections(t *testing.T) {
+	// Create a ranger character without metadata (shouldn't crash)
+	ranger := &entities.Character{
+		Name:  "Test Ranger",
+		Level: 1,
+		Features: []*entities.CharacterFeature{
+			{
+				Key:         "favored_enemy",
+				Name:        "Favored Enemy",
+				Type:        entities.FeatureTypeClass,
+				Description: "You have significant experience studying, tracking, hunting, and even talking to a certain type of enemy.",
+				// No metadata
+			},
+		},
+	}
+
+	lines := buildFeatureSummary(ranger)
+
+	// Should still show the feature, just without the selection
+	foundFavoredEnemy := false
+	for _, line := range lines {
+		if strings.Contains(line, "Favored Enemy") && !strings.Contains(line, "(") {
+			foundFavoredEnemy = true
+		}
+	}
+
+	if !foundFavoredEnemy {
+		t.Errorf("Expected to find 'Favored Enemy' in feature summary, got: %v", lines)
+	}
+}
+
+func TestBuildFeatureSummary_RangerHumanoids(t *testing.T) {
+	// Test the special case for humanoids
+	ranger := &entities.Character{
+		Name:  "Test Ranger",
+		Level: 1,
+		Features: []*entities.CharacterFeature{
+			{
+				Key:         "favored_enemy",
+				Name:        "Favored Enemy",
+				Type:        entities.FeatureTypeClass,
+				Description: "You have significant experience studying, tracking, hunting, and even talking to a certain type of enemy.",
+				Metadata: map[string]any{
+					"enemy_type": "humanoids",
+				},
+			},
+		},
+	}
+
+	lines := buildFeatureSummary(ranger)
+
+	// Check that humanoids shows as "Two Humanoid Races"
+	foundCorrectDisplay := false
+	for _, line := range lines {
+		if strings.Contains(line, "Favored Enemy (Two Humanoid Races)") {
+			foundCorrectDisplay = true
+		}
+	}
+
+	if !foundCorrectDisplay {
+		t.Errorf("Expected to find 'Favored Enemy (Two Humanoid Races)' in feature summary, got: %v", lines)
+	}
+}

--- a/internal/handlers/discord/dnd/character/sheet_test.go
+++ b/internal/handlers/discord/dnd/character/sheet_test.go
@@ -69,6 +69,9 @@ func TestBuildCharacterSheetEmbed(t *testing.T) {
 				Type:        entities.FeatureTypeClass,
 				Level:       1,
 				Source:      "Ranger",
+				Metadata: map[string]any{
+					"enemy_type": "orc",
+				},
 			},
 			{
 				Key:         "natural_explorer",
@@ -89,8 +92,8 @@ func TestBuildCharacterSheetEmbed(t *testing.T) {
 	assert.Contains(t, embed.Description, "**AC:** 16")
 	assert.Contains(t, embed.Description, "**Initiative:** +2")
 
-	// Verify fields
-	require.Len(t, embed.Fields, 4)
+	// Verify fields (5 because ranger has features/effects)
+	require.Len(t, embed.Fields, 5)
 
 	// Check ability scores field
 	assert.Equal(t, "📊 Ability Scores", embed.Fields[0].Name)


### PR DESCRIPTION
## Summary
This PR implements a generic class feature selection system for character creation, starting with Ranger's Favored Enemy and Natural Explorer features.

## Changes
- Add generic ClassFeaturesHandler for handling class-specific selections
- Implement Favored Enemy and Natural Explorer selection UIs for Rangers
- Add feature metadata storage using map[string]any (more modern than interface{})
- Insert class feature selection after ability assignment in character flow
- Update character initialization to use selected favored enemy type
- Add comprehensive tests for feature selection handlers
- Fix all errcheck linting issues by properly handling errors

## Feature Selection Flow
After assigning ability scores, rangers will now see:
1. Favored Enemy selection (choose enemy type for tracking/knowledge bonuses)
2. Natural Explorer selection (choose favored terrain type)

## Extensibility
This creates a reusable system that can be extended for other classes:
- Cleric (Divine Domain selection)
- Warlock (Patron selection) 
- Fighter (Fighting Style selection)
- Sorcerer (Sorcerous Origin selection)

## Testing
All tests pass except for a pre-existing issue in combat/ephemeral_test.go that also fails on main branch. This should be addressed in a separate PR.

Fixes #159