### PR TITLE
feat: Implement Martial Arts and Two-Weapon Fighting bonus actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ DISCORD_TOKEN=xxx REDIS_URL=redis://localhost:6379 ./bin/dnd-bot
 3. **Run pre-commit**: `make pre-commit` (never use --no-verify)
 4. **Update PR description** if scope changes
 5. **Use conventional commits**: feat:, fix:, refactor:, docs:, test:
+6. **Add QA Checklist**: Copy from `docs/qa-checklist-template.md` and check off manual verifications
 
 #### Pre-Commit Workflow
 **IMPORTANT**: Always run `make pre-commit` before committing code. This will:

--- a/docs/qa-checklist-template.md
+++ b/docs/qa-checklist-template.md
@@ -1,0 +1,112 @@
+# QA Checklist Template
+
+## Manual Verification Checklist
+
+Copy this checklist to your PR description and check off items as you verify them:
+
+### Combat Action Economy
+- [ ] **Martial Arts Bonus Action**
+  - [ ] Appears only after attacking with monk weapon or unarmed strike
+  - [ ] Disappears after being used
+  - [ ] Shows correct damage dice (d4 at level 1-4, d6 at 5-10, etc.)
+  - [ ] Uses DEX modifier for attack and damage rolls
+  - [ ] Combat log shows "(Martial Arts)" label
+
+- [ ] **Two-Weapon Fighting Bonus Action**
+  - [ ] Appears only after attacking with light melee weapon in main hand
+  - [ ] Requires light weapon in off-hand
+  - [ ] Shows correct weapon name in button
+  - [ ] Damage doesn't add ability modifier (unless Two-Weapon Fighting style)
+  - [ ] Combat log shows off-hand weapon name
+
+- [ ] **Action Economy Display**
+  - [ ] Action status shows ✅/❌ correctly
+  - [ ] Bonus action status shows ✅/❌ correctly
+  - [ ] Available bonus actions list updates dynamically
+  - [ ] Turn reset clears all action states
+
+### General Combat Flow
+- [ ] **Turn Order**
+  - [ ] Can only act on your turn
+  - [ ] "Not Your Turn" message appears with current player name
+  - [ ] Next Turn button advances correctly
+  - [ ] New round message appears when cycling back
+
+- [ ] **Attack Flow**
+  - [ ] Target selection shows valid targets only
+  - [ ] Attack results show hit/miss/critical correctly
+  - [ ] Damage is applied to target HP
+  - [ ] Defeated enemies are marked appropriately
+  - [ ] Combat ends when all enemies defeated
+
+### Abilities
+- [ ] **Rage (Barbarian)**
+  - [ ] Uses bonus action
+  - [ ] Shows duration remaining
+  - [ ] Adds +2 damage to melee attacks
+  - [ ] Persists across bot restarts
+
+- [ ] **Second Wind (Fighter)**
+  - [ ] Uses action (not bonus action)
+  - [ ] Heals 1d10 + fighter level
+  - [ ] Shows healing amount in log
+  - [ ] Once per short rest
+
+### Edge Cases
+- [ ] **Multiple Players**
+  - [ ] Each player gets own "Get My Actions" button
+  - [ ] Ephemeral messages are private
+  - [ ] Shared combat message updates for all
+
+- [ ] **Bot Restart**
+  - [ ] Combat state persists
+  - [ ] Character resources persist
+  - [ ] Active effects persist
+
+### Known Issues to Verify Fixed
+- [ ] Dead monsters don't attack
+- [ ] Rage marks bonus action as used
+- [ ] Equipment persistence works
+
+## How to Use This Checklist
+
+1. Copy the entire checklist to your PR description
+2. Test each item locally or in dev environment
+3. Check off items that work correctly
+4. Leave unchecked items that need fixing
+5. Add notes for any unexpected behavior
+
+Example PR description:
+```markdown
+## Description
+Implements monk martial arts bonus action and two-weapon fighting
+
+## QA Checklist
+- [x] **Martial Arts Bonus Action**
+  - [x] Appears only after attacking with monk weapon or unarmed strike
+  - [x] Disappears after being used
+  - [ ] Shows correct damage dice (needs fix - always showing d4)
+  ...
+```
+
+## Automated vs Manual Testing
+
+**Automated (Unit Tests)**
+- Damage calculations
+- Ability requirements
+- State transitions
+
+**Manual (This Checklist)**
+- Discord UI interactions
+- Message formatting
+- Button states
+- Multi-player scenarios
+- Visual feedback
+
+## Adding New Items
+
+When implementing new features, add corresponding QA items:
+1. What should happen (happy path)
+2. What shouldn't happen (validations)
+3. Edge cases specific to the feature
+4. Integration with existing features

--- a/internal/handlers/discord/handler.go
+++ b/internal/handlers/discord/handler.go
@@ -187,7 +187,7 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 		skillCheckHandler: oldcombat.NewSkillCheckHandler(&oldcombat.SkillCheckHandlerConfig{
 			CharacterService: cfg.ServiceProvider.CharacterService,
 		}),
-		combatHandler: combat.NewHandler(cfg.ServiceProvider.EncounterService, cfg.ServiceProvider.AbilityService),
+		combatHandler: combat.NewHandler(cfg.ServiceProvider.EncounterService, cfg.ServiceProvider.AbilityService, cfg.ServiceProvider.CharacterService),
 	}
 }
 


### PR DESCRIPTION
## Description
Implements bonus action mechanics for Monk Martial Arts and Two-Weapon Fighting, allowing players to make additional attacks as bonus actions when conditions are met.

## Changes
- ✨ Add bonus action buttons to combat UI when available
- 🥋 Show "Martial Arts Strike" after monk weapon/unarmed attacks
- ⚔️ Show "Off-Hand Attack" after light weapon attacks with light off-hand
- 🎯 Implement target selection for bonus actions
- 💥 Execute bonus attacks with proper damage calculations
- 📊 Display available bonus actions in player status

## Technical Details
- Updated combat handler to accept character service for bonus action checks
- Added `handleBonusAction` for showing target selection UI
- Added `handleBonusTarget` for executing the selected bonus attack
- Implemented `executeUnarmedStrike` with martial arts damage scaling (d4→d10)
- Implemented `executeOffHandAttack` with two-weapon fighting rules
- Bonus action state persists via `UpdateEquipment` call

## QA Checklist
- [ ] **Martial Arts Bonus Action**
  - [ ] Appears only after attacking with monk weapon or unarmed strike
  - [ ] Disappears after being used
  - [ ] Shows correct damage dice (d4 at level 1-4, d6 at 5-10, etc.)
  - [ ] Uses DEX modifier for attack and damage rolls
  - [ ] Combat log shows "(Martial Arts)" label

- [ ] **Two-Weapon Fighting Bonus Action**
  - [ ] Appears only after attacking with light melee weapon in main hand
  - [ ] Requires light weapon in off-hand
  - [ ] Shows correct weapon name in button
  - [ ] Damage doesn't add ability modifier (unless Two-Weapon Fighting style)
  - [ ] Combat log shows off-hand weapon name

- [ ] **Action Economy Display**
  - [ ] Action status shows ✅/❌ correctly
  - [ ] Bonus action status shows ✅/❌ correctly
  - [ ] Available bonus actions list updates dynamically
  - [ ] Turn reset clears all action states

- [ ] **General Combat Flow**
  - [ ] Can only act on your turn
  - [ ] "Not Your Turn" message appears with current player name
  - [ ] Attack results show hit/miss/critical correctly
  - [ ] Defeated enemies are marked appropriately

## Related Issues
- Partially addresses #1 (Monk Martial Arts feature)
- Partially addresses #2 (Two-Weapon Fighting)
- Builds on #187 (Action Economy System)

## Event-Driven Architecture Notes
This implementation demonstrates how features currently interact directly with the combat system. In an event-driven architecture:
- Martial Arts would listen for "AttackComplete" events
- Two-Weapon Fighting would check attack properties via event context
- Bonus actions would be registered dynamically by feature modules
- See #216 for more discussion on this approach