### PR TITLE
Clean up commands and add admin inventory management

### DIFF
--- a/internal/handlers/discord/dnd/admin/inventory.go
+++ b/internal/handlers/discord/dnd/admin/inventory.go
@@ -1,0 +1,301 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/entities/damage"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/services"
+	characterService "github.com/KirkDiggler/dnd-bot-discord/internal/services/character"
+	"github.com/bwmarrin/discordgo"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// InventoryHandler handles admin inventory commands
+type InventoryHandler struct {
+	characterService characterService.Service
+}
+
+// NewInventoryHandler creates a new inventory handler
+func NewInventoryHandler(serviceProvider *services.Provider) *InventoryHandler {
+	return &InventoryHandler{
+		characterService: serviceProvider.CharacterService,
+	}
+}
+
+// HandleGive handles the admin give command
+func (h *InventoryHandler) HandleGive(s *discordgo.Session, i *discordgo.InteractionCreate, characterName, itemKey string, quantity int64) error {
+	// Defer the response to give us more time
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to defer response: %w", err)
+	}
+
+	// Find the character by name for the user
+	characters, err := h.characterService.ListCharacters(context.Background(), i.Member.User.ID)
+	if err != nil {
+		return h.respondError(s, i, "Failed to list characters", err)
+	}
+
+	var targetChar *entities.Character
+	for _, char := range characters {
+		if char.Name == characterName {
+			targetChar = char
+			break
+		}
+	}
+
+	if targetChar == nil {
+		return h.respondError(s, i, fmt.Sprintf("Character '%s' not found", characterName), nil)
+	}
+
+	// For testing purposes, create a simple weapon based on the item key
+	// In a real implementation, this would fetch from the D&D API
+	var equipment entities.Equipment
+
+	switch itemKey {
+	case "longsword", "shortsword", "dagger", "rapier", "greatsword":
+		weapon := &entities.Weapon{
+			Base: entities.BasicEquipment{
+				Key:  itemKey,
+				Name: cases.Title(language.English).String(itemKey),
+			},
+			WeaponCategory: "Simple",
+			WeaponRange:    "Melee",
+		}
+
+		// Set damage based on weapon type
+		switch itemKey {
+		case "dagger":
+			weapon.Damage = &damage.Damage{DiceCount: 1, DiceSize: 4, DamageType: "piercing"}
+		case "shortsword":
+			weapon.Damage = &damage.Damage{DiceCount: 1, DiceSize: 6, DamageType: "piercing"}
+		case "rapier":
+			weapon.Damage = &damage.Damage{DiceCount: 1, DiceSize: 8, DamageType: "piercing"}
+			weapon.WeaponCategory = "Martial"
+		case "longsword":
+			weapon.Damage = &damage.Damage{DiceCount: 1, DiceSize: 8, DamageType: "slashing"}
+			weapon.WeaponCategory = "Martial"
+		case "greatsword":
+			weapon.Damage = &damage.Damage{DiceCount: 2, DiceSize: 6, DamageType: "slashing"}
+			weapon.TwoHandedDamage = weapon.Damage // Greatsword is always two-handed
+			weapon.WeaponCategory = "Martial"
+			weapon.Properties = []*entities.ReferenceItem{
+				{Key: "two-handed", Name: "Two-Handed"},
+				{Key: "heavy", Name: "Heavy"},
+			}
+		}
+
+		equipment = weapon
+	case "shield":
+		equipment = &entities.BasicEquipment{
+			Key:  itemKey,
+			Name: "Shield",
+		}
+	default:
+		// Generic item
+		equipment = &entities.BasicEquipment{
+			Key:  itemKey,
+			Name: cases.Title(language.English).String(strings.ReplaceAll(itemKey, "-", " ")),
+		}
+	}
+
+	// Initialize inventory map if needed
+	if targetChar.Inventory == nil {
+		targetChar.Inventory = make(map[entities.EquipmentType][]entities.Equipment)
+	}
+
+	// Determine equipment type
+	equipType := equipment.GetEquipmentType()
+	if equipType == "BasicEquipment" {
+		// Try to determine type from key
+		if itemKey == "shield" {
+			equipType = entities.EquipmentTypeArmor
+		} else {
+			equipType = entities.EquipmentTypeOther
+		}
+	}
+
+	// Add the item to the character's inventory
+	for j := int64(0); j < quantity; j++ {
+		targetChar.Inventory[equipType] = append(targetChar.Inventory[equipType], equipment)
+	}
+
+	// Save the character - use UpdateEquipment method
+	if updateErr := h.characterService.UpdateEquipment(targetChar); updateErr != nil {
+		return h.respondError(s, i, "Failed to save character", updateErr)
+	}
+
+	// Count total items
+	totalItems := 0
+	for _, items := range targetChar.Inventory {
+		totalItems += len(items)
+	}
+
+	// Send success response
+	embed := &discordgo.MessageEmbed{
+		Title:       "✅ Item Added",
+		Description: fmt.Sprintf("Added %d x **%s** to %s's inventory", quantity, equipment.GetName(), targetChar.Name),
+		Color:       0x00ff00,
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "Current Inventory Count",
+				Value:  fmt.Sprintf("%d items", totalItems),
+				Inline: true,
+			},
+		},
+	}
+
+	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Embeds: &[]*discordgo.MessageEmbed{embed},
+	})
+	return err
+}
+
+// HandleTake handles the admin take command
+func (h *InventoryHandler) HandleTake(s *discordgo.Session, i *discordgo.InteractionCreate, characterName, itemKey string, quantity int64) error {
+	// Defer the response to give us more time
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to defer response: %w", err)
+	}
+
+	// Find the character by name for the user
+	characters, err := h.characterService.ListCharacters(context.Background(), i.Member.User.ID)
+	if err != nil {
+		return h.respondError(s, i, "Failed to list characters", err)
+	}
+
+	var targetChar *entities.Character
+	for _, char := range characters {
+		if char.Name == characterName {
+			targetChar = char
+			break
+		}
+	}
+
+	if targetChar == nil {
+		return h.respondError(s, i, fmt.Sprintf("Character '%s' not found", characterName), nil)
+	}
+
+	// Count how many of this item the character has across all equipment types
+	itemCount := 0
+	itemName := ""
+	for _, items := range targetChar.Inventory {
+		for _, item := range items {
+			if item.GetKey() == itemKey {
+				itemCount++
+				if itemName == "" {
+					itemName = item.GetName()
+				}
+			}
+		}
+	}
+
+	if itemCount == 0 {
+		return h.respondError(s, i, fmt.Sprintf("Character doesn't have any '%s'", itemKey), nil)
+	}
+
+	// Determine how many to remove
+	removeCount := itemCount // Remove all by default
+	if quantity > 0 && int(quantity) < itemCount {
+		removeCount = int(quantity)
+	}
+
+	// Remove the items
+	removed := 0
+	for equipType, items := range targetChar.Inventory {
+		newItems := []entities.Equipment{}
+		for _, item := range items {
+			if item.GetKey() == itemKey && removed < removeCount {
+				removed++
+				continue
+			}
+			newItems = append(newItems, item)
+		}
+		if len(newItems) > 0 {
+			targetChar.Inventory[equipType] = newItems
+		} else {
+			// Remove empty equipment type entries
+			delete(targetChar.Inventory, equipType)
+		}
+	}
+
+	// Also check if the item is equipped and unequip if necessary
+	if targetChar.EquippedSlots != nil {
+		for slot, equipped := range targetChar.EquippedSlots {
+			if equipped != nil && equipped.GetKey() == itemKey {
+				delete(targetChar.EquippedSlots, slot)
+			}
+		}
+	}
+
+	// Save the character
+	if updateErr := h.characterService.UpdateEquipment(targetChar); updateErr != nil {
+		return h.respondError(s, i, "Failed to save character", updateErr)
+	}
+
+	// Count total items remaining
+	totalItems := 0
+	for _, items := range targetChar.Inventory {
+		totalItems += len(items)
+	}
+
+	// Send success response
+	embed := &discordgo.MessageEmbed{
+		Title:       "✅ Item Removed",
+		Description: fmt.Sprintf("Removed %d x **%s** from %s's inventory", removed, itemName, targetChar.Name),
+		Color:       0x00ff00,
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "Remaining in Inventory",
+				Value:  fmt.Sprintf("%d x %s", itemCount-removed, itemName),
+				Inline: true,
+			},
+			{
+				Name:   "Total Inventory Count",
+				Value:  fmt.Sprintf("%d items", totalItems),
+				Inline: true,
+			},
+		},
+	}
+
+	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Embeds: &[]*discordgo.MessageEmbed{embed},
+	})
+	return err
+}
+
+func (h *InventoryHandler) respondError(s *discordgo.Session, i *discordgo.InteractionCreate, message string, err error) error {
+	if err != nil {
+		log.Printf("Admin inventory error: %s: %v", message, err)
+	}
+
+	embed := &discordgo.MessageEmbed{
+		Title:       "❌ Error",
+		Description: message,
+		Color:       0xff0000,
+	}
+
+	_, editErr := s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Embeds: &[]*discordgo.MessageEmbed{embed},
+	})
+	if editErr != nil {
+		log.Printf("Failed to edit interaction response: %v", editErr)
+	}
+	return nil
+}

--- a/internal/handlers/discord/handler.go
+++ b/internal/handlers/discord/handler.go
@@ -11,12 +11,11 @@ import (
 	"github.com/KirkDiggler/dnd-bot-discord/internal/dice"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/entities"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/combat"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/dnd/admin"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/dnd/character"
 	oldcombat "github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/dnd/combat"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/dnd/dungeon"
-	encounterHandler "github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/dnd/encounter"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/dnd/help"
-	sessionHandler "github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/dnd/session"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/dnd/testcombat"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/helpers"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/services"
@@ -54,22 +53,9 @@ type Handler struct {
 	characterDetailsHandler               *character.CharacterDetailsHandler
 	characterListHandler                  *character.ListHandler
 	characterShowHandler                  *character.ShowHandler
-	characterEquipmentHandler             *character.EquipmentHandler
 	characterSheetHandler                 *character.SheetHandler
 	characterDeleteHandler                *character.DeleteHandler
 	characterClassFeaturesHandler         *character.ClassFeaturesHandler
-
-	// Session handlers
-	sessionCreateHandler *sessionHandler.CreateHandler
-	sessionListHandler   *sessionHandler.ListHandler
-	sessionJoinHandler   *sessionHandler.JoinHandler
-	sessionStartHandler  *sessionHandler.StartHandler
-	sessionEndHandler    *sessionHandler.EndHandler
-	sessionInfoHandler   *sessionHandler.InfoHandler
-	sessionLeaveHandler  *sessionHandler.LeaveHandler
-
-	// Encounter handlers
-	encounterAddMonsterHandler *encounterHandler.AddMonsterHandler
 
 	// Test combat handler
 	testCombatHandler *testcombat.TestCombatHandler
@@ -81,6 +67,9 @@ type Handler struct {
 
 	// Help handler
 	helpHandler *help.HelpHandler
+
+	// Admin handlers
+	adminInventoryHandler *admin.InventoryHandler
 
 	// Combat handlers
 	savingThrowHandler *oldcombat.SavingThrowHandler
@@ -147,26 +136,11 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 		characterDetailsHandler: character.NewCharacterDetailsHandler(&character.CharacterDetailsHandlerConfig{
 			CharacterService: cfg.ServiceProvider.CharacterService,
 		}),
-		characterListHandler: character.NewListHandler(cfg.ServiceProvider),
-		characterShowHandler: character.NewShowHandler(cfg.ServiceProvider),
-		characterEquipmentHandler: character.NewEquipmentHandler(&character.EquipmentHandlerConfig{
-			ServiceProvider: cfg.ServiceProvider,
-		}),
+		characterListHandler:          character.NewListHandler(cfg.ServiceProvider),
+		characterShowHandler:          character.NewShowHandler(cfg.ServiceProvider),
 		characterSheetHandler:         character.NewSheetHandler(cfg.ServiceProvider),
 		characterDeleteHandler:        character.NewDeleteHandler(cfg.ServiceProvider),
 		characterClassFeaturesHandler: character.NewClassFeaturesHandler(cfg.ServiceProvider.CharacterService),
-
-		// Initialize session handlers
-		sessionCreateHandler: sessionHandler.NewCreateHandler(cfg.ServiceProvider),
-		sessionListHandler:   sessionHandler.NewListHandler(cfg.ServiceProvider),
-		sessionJoinHandler:   sessionHandler.NewJoinHandler(cfg.ServiceProvider),
-		sessionStartHandler:  sessionHandler.NewStartHandler(cfg.ServiceProvider),
-		sessionEndHandler:    sessionHandler.NewEndHandler(cfg.ServiceProvider),
-		sessionInfoHandler:   sessionHandler.NewInfoHandler(cfg.ServiceProvider),
-		sessionLeaveHandler:  sessionHandler.NewLeaveHandler(cfg.ServiceProvider),
-
-		// Initialize encounter handlers
-		encounterAddMonsterHandler: encounterHandler.NewAddMonsterHandler(cfg.ServiceProvider),
 
 		// Initialize test combat handler
 		testCombatHandler: testcombat.NewTestCombatHandler(cfg.ServiceProvider),
@@ -178,6 +152,9 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 
 		// Initialize help handler
 		helpHandler: help.NewHelpHandler(),
+
+		// Initialize admin handlers
+		adminInventoryHandler: admin.NewInventoryHandler(cfg.ServiceProvider),
 
 		// Initialize combat handlers
 		savingThrowHandler: oldcombat.NewSavingThrowHandler(&oldcombat.SavingThrowHandlerConfig{
@@ -217,162 +194,6 @@ func (h *Handler) RegisterCommands(s *discordgo.Session, guildID string) error {
 							Name:        "delete",
 							Description: "Delete one of your characters",
 							Type:        discordgo.ApplicationCommandOptionSubCommand,
-						},
-						{
-							Name:        "equip",
-							Description: "Equip a weapon or shield",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Options: []*discordgo.ApplicationCommandOption{
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "character_id",
-									Description: "Character ID",
-									Required:    true,
-								},
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "item",
-									Description: "Weapon or shield key (e.g., 'longsword', 'shield')",
-									Required:    true,
-								},
-							},
-						},
-						{
-							Name:        "unequip",
-							Description: "Unequip an item from a slot",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Options: []*discordgo.ApplicationCommandOption{
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "character_id",
-									Description: "Character ID",
-									Required:    true,
-								},
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "slot",
-									Description: "Slot to unequip (main-hand, off-hand, body)",
-									Required:    true,
-									Choices: []*discordgo.ApplicationCommandOptionChoice{
-										{Name: "Main Hand", Value: "main-hand"},
-										{Name: "Off Hand", Value: "off-hand"},
-										{Name: "Body", Value: "body"},
-									},
-								},
-							},
-						},
-						{
-							Name:        "inventory",
-							Description: "Show character's inventory",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Options: []*discordgo.ApplicationCommandOption{
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "character_id",
-									Description: "Character ID",
-									Required:    true,
-								},
-							},
-						},
-					},
-				},
-				{
-					Name:        "session",
-					Description: "Session management commands",
-					Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
-					Options: []*discordgo.ApplicationCommandOption{
-						{
-							Name:        "create",
-							Description: "Create a new game session",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Options: []*discordgo.ApplicationCommandOption{
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "name",
-									Description: "Session name",
-									Required:    true,
-								},
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "description",
-									Description: "Session description (optional)",
-									Required:    false,
-								},
-							},
-						},
-						{
-							Name:        "list",
-							Description: "List all your sessions",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-						},
-						{
-							Name:        "join",
-							Description: "Join a session with invite code",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Options: []*discordgo.ApplicationCommandOption{
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "code",
-									Description: "Invite code",
-									Required:    true,
-								},
-							},
-						},
-						{
-							Name:        "info",
-							Description: "Show info about your current session",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-						},
-						{
-							Name:        "start",
-							Description: "Start a session (DM only)",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Options: []*discordgo.ApplicationCommandOption{
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "id",
-									Description: "Session ID (optional if you have only one session)",
-									Required:    false,
-								},
-							},
-						},
-						{
-							Name:        "end",
-							Description: "End a session (DM only)",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Options: []*discordgo.ApplicationCommandOption{
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "id",
-									Description: "Session ID (optional if you have only one session)",
-									Required:    false,
-								},
-							},
-						},
-						{
-							Name:        "leave",
-							Description: "Leave all your active sessions",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-						},
-					},
-				},
-				{
-					Name:        "encounter",
-					Description: "Encounter and combat management",
-					Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
-					Options: []*discordgo.ApplicationCommandOption{
-						{
-							Name:        "add",
-							Description: "Add a monster to the encounter",
-							Type:        discordgo.ApplicationCommandOptionSubCommand,
-							Options: []*discordgo.ApplicationCommandOption{
-								{
-									Type:        discordgo.ApplicationCommandOptionString,
-									Name:        "monster",
-									Description: "Monster name to search for",
-									Required:    true,
-								},
-							},
 						},
 					},
 				},
@@ -416,6 +237,63 @@ func (h *Handler) RegisterCommands(s *discordgo.Session, guildID string) error {
 								{Name: "Easy", Value: "easy"},
 								{Name: "Medium", Value: "medium"},
 								{Name: "Hard", Value: "hard"},
+							},
+						},
+					},
+				},
+				{
+					Name:        "admin",
+					Description: "Admin commands for testing",
+					Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
+					Options: []*discordgo.ApplicationCommandOption{
+						{
+							Name:        "give",
+							Description: "Give an item to a character (testing only)",
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+							Options: []*discordgo.ApplicationCommandOption{
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "character",
+									Description: "Character name",
+									Required:    true,
+								},
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "item",
+									Description: "Item key (e.g., 'longsword', 'shield', 'dagger')",
+									Required:    true,
+								},
+								{
+									Type:        discordgo.ApplicationCommandOptionInteger,
+									Name:        "quantity",
+									Description: "Quantity (default: 1)",
+									Required:    false,
+								},
+							},
+						},
+						{
+							Name:        "take",
+							Description: "Remove an item from a character (testing only)",
+							Type:        discordgo.ApplicationCommandOptionSubCommand,
+							Options: []*discordgo.ApplicationCommandOption{
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "character",
+									Description: "Character name",
+									Required:    true,
+								},
+								{
+									Type:        discordgo.ApplicationCommandOptionString,
+									Name:        "item",
+									Description: "Item key to remove",
+									Required:    true,
+								},
+								{
+									Type:        discordgo.ApplicationCommandOptionInteger,
+									Name:        "quantity",
+									Description: "Quantity to remove (default: all)",
+									Required:    false,
+								},
 							},
 						},
 					},
@@ -551,183 +429,51 @@ func (h *Handler) handleCommand(s *discordgo.Session, i *discordgo.InteractionCr
 			if err := h.characterDeleteHandler.Handle(req); err != nil {
 				log.Printf("Error handling character delete: %v", err)
 			}
-		case "equip":
-			if err := h.characterEquipmentHandler.HandleEquip(s, i); err != nil {
-				log.Printf("Error handling character equip: %v", err)
-			}
-		case "unequip":
-			if err := h.characterEquipmentHandler.HandleUnequip(s, i); err != nil {
-				log.Printf("Error handling character unequip: %v", err)
-			}
-		case "inventory":
-			if err := h.characterEquipmentHandler.HandleInventory(s, i); err != nil {
-				log.Printf("Error handling character inventory: %v", err)
-			}
 		}
-	} else if subcommandGroup.Name == "session" && len(subcommandGroup.Options) > 0 {
+	} else if subcommandGroup.Name == "admin" && len(subcommandGroup.Options) > 0 {
 		subcommand := subcommandGroup.Options[0]
 
 		switch subcommand.Name {
-		case "create":
-			// Get name and description from options
-			var name, description string
+		case "give":
+			// Handle give item command
+			var characterName, itemKey string
+			var quantity int64 = 1 // default quantity
+
 			for _, opt := range subcommand.Options {
 				switch opt.Name {
-				case "name":
-					name = opt.StringValue()
-				case "description":
-					description = opt.StringValue()
-				}
-			}
-			req := &sessionHandler.CreateRequest{
-				Session:     s,
-				Interaction: i,
-				Name:        name,
-				Description: description,
-			}
-			if err := h.sessionCreateHandler.Handle(req); err != nil {
-				log.Printf("Error handling session create: %v", err)
-			}
-		case "list":
-			req := &sessionHandler.ListRequest{
-				Session:     s,
-				Interaction: i,
-			}
-			if err := h.sessionListHandler.Handle(req); err != nil {
-				log.Printf("Error handling session list: %v", err)
-			}
-		case "join":
-			// Get invite code from options
-			var code string
-			for _, opt := range subcommand.Options {
-				if opt.Name == "code" {
-					code = opt.StringValue()
-					break
-				}
-			}
-			req := &sessionHandler.JoinRequest{
-				Session:     s,
-				Interaction: i,
-				InviteCode:  code,
-			}
-			if err := h.sessionJoinHandler.Handle(req); err != nil {
-				log.Printf("Error handling session join: %v", err)
-			}
-		case "info":
-			req := &sessionHandler.InfoRequest{
-				Session:     s,
-				Interaction: i,
-			}
-			if err := h.sessionInfoHandler.Handle(req); err != nil {
-				log.Printf("Error handling session info: %v", err)
-			}
-		case "start":
-			// Get session ID from options (optional)
-			var sessionID string
-			for _, opt := range subcommand.Options {
-				if opt.Name == "id" {
-					sessionID = opt.StringValue()
-					break
+				case "character":
+					characterName = opt.StringValue()
+				case "item":
+					itemKey = opt.StringValue()
+				case "quantity":
+					quantity = opt.IntValue()
 				}
 			}
 
-			// If no session ID provided, try to find the user's session
-			if sessionID == "" {
-				sessions, err := h.ServiceProvider.SessionService.ListUserSessions(context.Background(), i.Member.User.ID)
-				if err == nil && len(sessions) == 1 {
-					sessionID = sessions[0].ID
-				} else if len(sessions) > 1 {
-					// User has multiple sessions, they need to specify
-					err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseChannelMessageWithSource,
-						Data: &discordgo.InteractionResponseData{
-							Content: "❌ You have multiple sessions. Please specify the session ID.",
-							Flags:   discordgo.MessageFlagsEphemeral,
-						},
-					})
-					if err != nil {
-						log.Printf("Error responding to start command: %v", err)
+			if err := h.adminInventoryHandler.HandleGive(s, i, characterName, itemKey, quantity); err != nil {
+				log.Printf("Error handling admin give: %v", err)
+			}
+
+		case "take":
+			// Handle take item command
+			var characterName, itemKey string
+			var quantity int64 = -1 // -1 means remove all
+
+			for _, opt := range subcommand.Options {
+				switch opt.Name {
+				case "character":
+					characterName = opt.StringValue()
+				case "item":
+					itemKey = opt.StringValue()
+				case "quantity":
+					if opt.IntValue() > 0 {
+						quantity = opt.IntValue()
 					}
-					return
 				}
 			}
 
-			req := &sessionHandler.StartRequest{
-				Session:     s,
-				Interaction: i,
-				SessionID:   sessionID,
-			}
-			if err := h.sessionStartHandler.Handle(req); err != nil {
-				log.Printf("Error handling session start: %v", err)
-			}
-		case "end":
-			// Get session ID from options (optional)
-			var sessionID string
-			for _, opt := range subcommand.Options {
-				if opt.Name == "id" {
-					sessionID = opt.StringValue()
-					break
-				}
-			}
-
-			// If no session ID provided, try to find the user's session
-			if sessionID == "" {
-				sessions, err := h.ServiceProvider.SessionService.ListUserSessions(context.Background(), i.Member.User.ID)
-				if err == nil && len(sessions) == 1 {
-					sessionID = sessions[0].ID
-				} else if len(sessions) > 1 {
-					// User has multiple sessions, they need to specify
-					err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseChannelMessageWithSource,
-						Data: &discordgo.InteractionResponseData{
-							Content: "❌ You have multiple sessions. Please specify the session ID.",
-							Flags:   discordgo.MessageFlagsEphemeral,
-						},
-					})
-					if err != nil {
-						log.Printf("Error responding to end command: %v", err)
-					}
-					return
-				}
-			}
-
-			req := &sessionHandler.EndRequest{
-				Session:     s,
-				Interaction: i,
-				SessionID:   sessionID,
-			}
-			if err := h.sessionEndHandler.Handle(req); err != nil {
-				log.Printf("Error handling session end: %v", err)
-			}
-		case "leave":
-			req := &sessionHandler.LeaveRequest{
-				Session:     s,
-				Interaction: i,
-			}
-			if err := h.sessionLeaveHandler.Handle(req); err != nil {
-				log.Printf("Error handling session leave: %v", err)
-			}
-		}
-	} else if subcommandGroup.Name == "encounter" && len(subcommandGroup.Options) > 0 {
-		subcommand := subcommandGroup.Options[0]
-
-		if subcommand.Name == "add" {
-			// Get monster name from options
-			var monsterQuery string
-			for _, opt := range subcommand.Options {
-				if opt.Name == "monster" {
-					monsterQuery = opt.StringValue()
-					break
-				}
-			}
-
-			req := &encounterHandler.AddMonsterRequest{
-				Session:     s,
-				Interaction: i,
-				Query:       monsterQuery,
-			}
-			if err := h.encounterAddMonsterHandler.Handle(req); err != nil {
-				log.Printf("Error handling add monster: %v", err)
+			if err := h.adminInventoryHandler.HandleTake(s, i, characterName, itemKey, quantity); err != nil {
+				log.Printf("Error handling admin take: %v", err)
 			}
 		}
 	}
@@ -2205,9 +1951,13 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 					desc := ""
 					switch item := invItem.(type) {
 					case *entities.Weapon:
-						desc = fmt.Sprintf("Damage: %dd%d", item.Damage.DiceCount, item.Damage.DiceSize)
-						if item.Damage.Bonus > 0 {
-							desc += fmt.Sprintf("+%d", item.Damage.Bonus)
+						if item.Damage != nil {
+							desc = fmt.Sprintf("Damage: %dd%d", item.Damage.DiceCount, item.Damage.DiceSize)
+							if item.Damage.Bonus > 0 {
+								desc += fmt.Sprintf("+%d", item.Damage.Bonus)
+							}
+						} else {
+							desc = "No damage data"
 						}
 					case *entities.Armor:
 						if item.ArmorClass != nil {
@@ -2749,368 +2499,6 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 			})
 			if err != nil {
 				log.Printf("Error showing unequip success: %v", err)
-			}
-		}
-	} else if ctx == "session_manage" {
-		// Handle session management actions
-		if len(parts) >= 3 {
-			sessionID := parts[2]
-
-			switch action {
-			case "start":
-				// Start the session
-				err := h.ServiceProvider.SessionService.StartSession(context.Background(), sessionID, i.Member.User.ID)
-				if err != nil {
-					content := fmt.Sprintf("❌ Failed to start session: %v", err)
-					err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseChannelMessageWithSource,
-						Data: &discordgo.InteractionResponseData{
-							Content: content,
-							Flags:   discordgo.MessageFlagsEphemeral,
-						},
-					})
-					if err != nil {
-						log.Printf("Error responding to start session: %v", err)
-					}
-					return
-				}
-
-				err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-					Type: discordgo.InteractionResponseChannelMessageWithSource,
-					Data: &discordgo.InteractionResponseData{
-						Content: "🎲 Session started! Let the adventure begin!",
-						Flags:   discordgo.MessageFlagsEphemeral,
-					},
-				})
-				if err != nil {
-					log.Printf("Error starting session: %v", err)
-				}
-			case "leave":
-				// Leave the session
-				err := h.ServiceProvider.SessionService.LeaveSession(context.Background(), sessionID, i.Member.User.ID)
-				if err != nil {
-					content := fmt.Sprintf("❌ Failed to leave session: %v", err)
-					err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseChannelMessageWithSource,
-						Data: &discordgo.InteractionResponseData{
-							Content: content,
-							Flags:   discordgo.MessageFlagsEphemeral,
-						},
-					})
-					if err != nil {
-						log.Printf("Error responding to leave session: %v", err)
-					}
-					return
-				}
-
-				err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-					Type: discordgo.InteractionResponseChannelMessageWithSource,
-					Data: &discordgo.InteractionResponseData{
-						Content: "👋 You've left the session.",
-						Flags:   discordgo.MessageFlagsEphemeral,
-					},
-				})
-				if err != nil {
-					log.Printf("Error leaving session: %v", err)
-				}
-			case "select_character":
-				// Show character selection menu
-				// Get user's characters
-				chars, err := h.ServiceProvider.CharacterService.ListByOwner(i.Member.User.ID)
-				if err != nil || len(chars) == 0 {
-					content := "❌ You need to create a character first! Use `/dnd character create`"
-					err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseChannelMessageWithSource,
-						Data: &discordgo.InteractionResponseData{
-							Content: content,
-							Flags:   discordgo.MessageFlagsEphemeral,
-						},
-					})
-					if err != nil {
-						log.Printf("Error responding with error: %v", err)
-					}
-					return
-				}
-
-				// Build character options
-				options := make([]discordgo.SelectMenuOption, 0, len(chars))
-				for _, char := range chars {
-					if char.Status == entities.CharacterStatusActive {
-						options = append(options, discordgo.SelectMenuOption{
-							Label:       fmt.Sprintf("%s - %s", char.Name, char.GetDisplayInfo()),
-							Description: fmt.Sprintf("Level %d | HP: %d/%d | AC: %d", char.Level, char.CurrentHitPoints, char.MaxHitPoints, char.AC),
-							Value:       char.ID,
-						})
-					}
-				}
-
-				if len(options) == 0 {
-					content := "❌ You don't have any active characters! Create or activate a character first."
-					err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseChannelMessageWithSource,
-						Data: &discordgo.InteractionResponseData{
-							Content: content,
-							Flags:   discordgo.MessageFlagsEphemeral,
-						},
-					})
-					if err != nil {
-						log.Printf("Error responding with error: %v", err)
-					}
-					return
-				}
-
-				// Show character selection menu
-				err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-					Type: discordgo.InteractionResponseChannelMessageWithSource,
-					Data: &discordgo.InteractionResponseData{
-						Content: "🎭 Select your character for this session:",
-						Flags:   discordgo.MessageFlagsEphemeral,
-						Components: []discordgo.MessageComponent{
-							discordgo.ActionsRow{
-								Components: []discordgo.MessageComponent{
-									discordgo.SelectMenu{
-										CustomID:    fmt.Sprintf("session_manage:confirm_character:%s", sessionID),
-										Placeholder: "Choose your character...",
-										Options:     options,
-									},
-								},
-							},
-						},
-					},
-				})
-				if err != nil {
-					log.Printf("Error showing character selection: %v", err)
-				}
-			case "confirm_character":
-				// Set the selected character
-				if len(i.MessageComponentData().Values) > 0 {
-					characterID := i.MessageComponentData().Values[0]
-					err := h.ServiceProvider.SessionService.SelectCharacter(context.Background(), sessionID, i.Member.User.ID, characterID)
-					if err != nil {
-						content := fmt.Sprintf("❌ Failed to select character: %v", err)
-						err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-							Type: discordgo.InteractionResponseUpdateMessage,
-							Data: &discordgo.InteractionResponseData{
-								Content:    content,
-								Components: []discordgo.MessageComponent{},
-							},
-						})
-						if err != nil {
-							log.Printf("Error responding with error: %v", err)
-						}
-						return
-					}
-
-					// Get character details for confirmation
-					char, charErr := h.ServiceProvider.CharacterService.GetByID(characterID)
-					if charErr != nil {
-						content := fmt.Sprintf("❌ Failed to get character: %v", charErr)
-						err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-							Type: discordgo.InteractionResponseUpdateMessage,
-							Data: &discordgo.InteractionResponseData{
-								Content:    content,
-								Components: []discordgo.MessageComponent{},
-							},
-						})
-						if err != nil {
-							log.Printf("Error responding with error: %v", err)
-						}
-						return
-					}
-					content := fmt.Sprintf("✅ Character selected: **%s** the %s", char.Name, char.GetDisplayInfo())
-					err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseUpdateMessage,
-						Data: &discordgo.InteractionResponseData{
-							Content:    content,
-							Components: []discordgo.MessageComponent{},
-						},
-					})
-					if err != nil {
-						log.Printf("Error confirming character selection: %v", err)
-					}
-
-					// Check if there's an active encounter in this session
-					// If so, we need to add the player to it and update the shared message
-					enc, encErr := h.ServiceProvider.EncounterService.GetActiveEncounter(context.Background(), sessionID)
-					if encErr != nil {
-						// Log the error but don't fail - there might not be an active encounter
-						log.Printf("No active encounter found for session %s: %v", sessionID, encErr)
-					} else if enc != nil {
-						log.Printf("Found active encounter %s, adding player %s with character %s", enc.ID, i.Member.User.ID, characterID)
-
-						// Check if player is already in the encounter with a different character
-						var existingCombatantID string
-						for id, combatant := range enc.Combatants {
-							if combatant.PlayerID == i.Member.User.ID {
-								log.Printf("Player %s is already in encounter as %s (combatant %s)", i.Member.User.ID, combatant.Name, id)
-								existingCombatantID = id
-								break
-							}
-						}
-
-						if existingCombatantID != "" {
-							// Remove the old combatant first
-							log.Printf("Removing old combatant %s to replace with new character", existingCombatantID)
-							removeErr := h.ServiceProvider.EncounterService.RemoveCombatant(context.Background(), enc.ID, existingCombatantID, i.Member.User.ID)
-							if removeErr != nil {
-								log.Printf("Failed to remove old combatant: %v", removeErr)
-							}
-						}
-
-						// Add the player with the new character
-						_, addErr := h.ServiceProvider.EncounterService.AddPlayer(context.Background(), enc.ID, i.Member.User.ID, characterID)
-						if addErr != nil {
-							log.Printf("Failed to add player to active encounter: %v", addErr)
-						} else {
-							log.Printf("Successfully added player %s to encounter %s with new character", i.Member.User.ID, enc.ID)
-						}
-
-						// Always try to update the shared combat message after character selection
-						// This ensures the display is current even if the player was already in the encounter
-						log.Printf("Updating shared combat message for encounter %s", enc.ID)
-
-						// Get fresh encounter data
-						updatedEnc, getErr := h.ServiceProvider.EncounterService.GetEncounter(context.Background(), enc.ID)
-						if getErr != nil {
-							log.Printf("Failed to get updated encounter: %v", getErr)
-						} else if updatedEnc != nil {
-							log.Printf("Got updated encounter. MessageID: %s, ChannelID: %s", updatedEnc.MessageID, updatedEnc.ChannelID)
-
-							if updatedEnc.MessageID != "" && updatedEnc.ChannelID != "" {
-								// Build the combat status embed
-								embed := combat.BuildCombatStatusEmbed(updatedEnc, nil)
-								components := combat.BuildCombatComponents(updatedEnc.ID, &encounter.ExecuteAttackResult{})
-
-								// Update the shared message
-								log.Printf("Attempting to update message %s in channel %s", updatedEnc.MessageID, updatedEnc.ChannelID)
-								_, err := s.ChannelMessageEditComplex(&discordgo.MessageEdit{
-									ID:         updatedEnc.MessageID,
-									Channel:    updatedEnc.ChannelID,
-									Embeds:     &[]*discordgo.MessageEmbed{embed},
-									Components: &components,
-								})
-								if err != nil {
-									log.Printf("Failed to update shared combat message: %v", err)
-								} else {
-									log.Printf("Successfully updated shared combat message")
-								}
-							} else {
-								log.Printf("Encounter %s has no message ID stored (MessageID: %s, ChannelID: %s)", updatedEnc.ID, updatedEnc.MessageID, updatedEnc.ChannelID)
-							}
-						}
-					}
-				}
-			case "pause":
-				// Pause the session
-				err := h.ServiceProvider.SessionService.PauseSession(context.Background(), sessionID, i.Member.User.ID)
-				if err != nil {
-					content := fmt.Sprintf("❌ Failed to pause session: %v", err)
-					err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseChannelMessageWithSource,
-						Data: &discordgo.InteractionResponseData{
-							Content: content,
-							Flags:   discordgo.MessageFlagsEphemeral,
-						},
-					})
-					if err != nil {
-						log.Printf("Error responding with error: %v", err)
-					}
-					return
-				}
-
-				err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-					Type: discordgo.InteractionResponseChannelMessageWithSource,
-					Data: &discordgo.InteractionResponseData{
-						Content: "⏸️ Session paused. Use `/dnd session info` to see options.",
-						Flags:   discordgo.MessageFlagsEphemeral,
-					},
-				})
-				if err != nil {
-					log.Printf("Error pausing session: %v", err)
-				}
-			case "end":
-				// Use the end handler
-				req := &sessionHandler.EndRequest{
-					Session:     s,
-					Interaction: i,
-					SessionID:   sessionID,
-				}
-				if err := h.sessionEndHandler.Handle(req); err != nil {
-					log.Printf("Error handling session end button: %v", err)
-				}
-			case "resume":
-				// Resume the session
-				err := h.ServiceProvider.SessionService.ResumeSession(context.Background(), sessionID, i.Member.User.ID)
-				if err != nil {
-					content := fmt.Sprintf("❌ Failed to resume session: %v", err)
-					err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseChannelMessageWithSource,
-						Data: &discordgo.InteractionResponseData{
-							Content: content,
-							Flags:   discordgo.MessageFlagsEphemeral,
-						},
-					})
-					if err != nil {
-						log.Printf("Error responding with error: %v", err)
-					}
-					return
-				}
-
-				err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-					Type: discordgo.InteractionResponseChannelMessageWithSource,
-					Data: &discordgo.InteractionResponseData{
-						Content: "▶️ Session resumed! The adventure continues!",
-						Flags:   discordgo.MessageFlagsEphemeral,
-					},
-				})
-				if err != nil {
-					log.Printf("Error resuming session: %v", err)
-				}
-			case "invite":
-				// Show invite interface
-				// Get session details
-				session, err := h.ServiceProvider.SessionService.GetSession(context.Background(), sessionID)
-				if err != nil {
-					content := fmt.Sprintf("❌ Failed to get session: %v", err)
-					err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-						Type: discordgo.InteractionResponseChannelMessageWithSource,
-						Data: &discordgo.InteractionResponseData{
-							Content: content,
-							Flags:   discordgo.MessageFlagsEphemeral,
-						},
-					})
-					if err != nil {
-						log.Printf("Error responding with error: %v", err)
-					}
-					return
-				}
-
-				// Show invite code and instructions
-				content := fmt.Sprintf("📨 **Invite Players to %s**\n\n🔑 Invite Code: `%s`\n\nPlayers can join using:\n```/dnd session join %s```",
-					session.Name, session.InviteCode, session.InviteCode)
-				err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-					Type: discordgo.InteractionResponseChannelMessageWithSource,
-					Data: &discordgo.InteractionResponseData{
-						Content: content,
-						Flags:   discordgo.MessageFlagsEphemeral,
-					},
-				})
-				if err != nil {
-					log.Printf("Error showing invite: %v", err)
-				}
-			case "settings":
-				// TODO: Implement session settings modal
-				content := "🔧 Session settings coming soon!"
-				err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-					Type: discordgo.InteractionResponseChannelMessageWithSource,
-					Data: &discordgo.InteractionResponseData{
-						Content: content,
-						Flags:   discordgo.MessageFlagsEphemeral,
-					},
-				})
-				if err != nil {
-					log.Printf("Error showing settings placeholder: %v", err)
-				}
 			}
 		}
 	} else if ctx == "combat" {


### PR DESCRIPTION
## Summary
- Removed duplicate character commands that required character_id parameter  
- Removed session and encounter command groups entirely
- Added admin command group for testing inventory management
- Fixed panic when displaying weapons without damage data

## Changes
### Command Cleanup
- Removed `/dnd character equip`, `/dnd character unequip`, `/dnd character inventory` (these required character_id)
- Removed entire session command group and all related handlers
- Removed encounter command group
- Cleaned up imports and removed unused handler fields

### Admin Commands Added
- `/dnd admin give` - Give items to a character for testing
- `/dnd admin take` - Remove items from a character for testing
- Both commands use character name instead of ID for better usability

### Bug Fixes
- Added nil check for weapon damage to prevent panic
- Admin-created weapons now include proper damage data

## Testing
- [x] Build passes
- [x] All tests pass
- [x] Admin give command works
- [x] Admin take command works with quantity
- [x] No panic when viewing inventory

## Notes
The Discord command cache may still show old commands until the bot is restarted and Discord refreshes.

Related: #219 (Monk martial arts damage die issue discovered during testing)