### PR TITLE
feat: add rpg-toolkit event bus adapter

### DIFF
--- a/docs/examples/rpg-toolkit-adapter-usage.md
+++ b/docs/examples/rpg-toolkit-adapter-usage.md
@@ -1,0 +1,168 @@
+# RPG Toolkit Event Bus Adapter Usage Examples
+
+This document shows how to use the RPG Toolkit event bus adapter to integrate rpg-toolkit's event system with the Discord bot.
+
+## Basic Setup
+
+```go
+package main
+
+import (
+    "github.com/KirkDiggler/dnd-bot-discord/internal/adapters/rpgtoolkit"
+    "github.com/KirkDiggler/dnd-bot-discord/internal/domain/events"
+)
+
+func main() {
+    // Create the adapter
+    eventBus := rpgtoolkit.NewEventBusAdapter()
+    
+    // Use it like the regular Discord bot event bus
+    // but get the benefits of rpg-toolkit's features
+}
+```
+
+## Example 1: Subscribing to Attack Events
+
+```go
+// Subscribe to attack roll events
+eventBus.Subscribe(events.BeforeAttackRoll, &AttackModifierHandler{})
+
+// Handler that adds bless bonus to attacks
+type AttackModifierHandler struct{}
+
+func (h *AttackModifierHandler) Handle(event interface{}) {
+    attackEvent, ok := event.(*events.AttackEvent)
+    if !ok {
+        return
+    }
+    
+    // Check if attacker has bless
+    if attackEvent.Attacker.HasStatusEffect("blessed") {
+        // In rpg-toolkit, this would add a modifier to the event context
+        // For now, we'd need to handle it in the Discord bot way
+    }
+}
+```
+
+## Example 2: Publishing Spell Events
+
+```go
+// When a spell is cast
+spellEvent := &events.SpellEvent{
+    Caster:     caster,
+    Targets:    targets,
+    SpellName:  "vicious-mockery",
+    SpellLevel: 0, // Cantrip
+    SaveDC:     13,
+    SaveType:   "wisdom",
+}
+
+// Publish through the adapter
+err := eventBus.Publish(events.OnSpellCast, spellEvent)
+if err != nil {
+    log.Printf("Failed to publish spell event: %v", err)
+}
+```
+
+## Example 3: Using RPG Toolkit Features Directly
+
+Since the adapter exposes the underlying rpg-toolkit bus, you can also use rpg-toolkit features directly:
+
+```go
+// Get the rpg-toolkit bus
+rpgBus := eventBus.GetRPGBus()
+
+// Create a disadvantage condition using rpg-toolkit
+import (
+    rpgevents "github.com/KirkDiggler/rpg-toolkit/events"
+    "github.com/KirkDiggler/rpg-toolkit/mechanics/conditions"
+)
+
+// Subscribe directly to rpg-toolkit events
+rpgBus.SubscribeFunc(rpgevents.EventBeforeAttackRoll, 100, func(ctx context.Context, e rpgevents.Event) error {
+    // Check if attacker has disadvantage from vicious mockery
+    if e.Source() != nil {
+        // This is where we'd check for the disadvantage condition
+        // and apply it to the attack roll
+    }
+    return nil
+})
+```
+
+## Example 4: Vicious Mockery with Event System
+
+```go
+// In vicious_mockery.go
+func (v *ViciousMockeryHandler) Execute(ctx context.Context, input *SpellInput) (*SpellResult, error) {
+    // ... save logic ...
+    
+    if saveFailed {
+        // Publish damage event
+        damageEvent := &events.DamageEvent{
+            Source:     input.Caster,
+            Target:     target,
+            Damage:     damage,
+            DamageType: "psychic",
+        }
+        
+        err := v.eventBus.Publish(events.OnSpellDamage, damageEvent)
+        if err != nil {
+            return nil, err
+        }
+        
+        // Apply disadvantage effect
+        // This would be better handled through rpg-toolkit conditions
+        // but for now we use the existing system
+        disadvantageEffect := effects.NewBuilder().
+            WithName("Vicious Mockery").
+            WithDuration(effects.DurationRounds, 1).
+            WithCondition(effects.ConditionDisadvantageAttack, "").
+            Build()
+            
+        target.AddStatusEffect(disadvantageEffect)
+    }
+    
+    return result, nil
+}
+```
+
+## Migration Path
+
+1. **Phase 1**: Use the adapter as a drop-in replacement for the current event bus
+2. **Phase 2**: Start using rpg-toolkit modifiers in event handlers
+3. **Phase 3**: Migrate conditions/effects to rpg-toolkit's system
+4. **Phase 4**: Remove Discord bot's event system entirely
+
+## Benefits of Using the Adapter
+
+1. **Cancellable Events**: Can implement counterspell by cancelling spell events
+2. **Event Priorities**: Handlers execute in a defined order
+3. **Better Modifiers**: Use rpg-toolkit's typed modifier system
+4. **Future-Proof**: Easy migration path to full rpg-toolkit integration
+
+## Testing
+
+```go
+func TestViciousMockeryWithAdapter(t *testing.T) {
+    // Create adapter
+    eventBus := rpgtoolkit.NewEventBusAdapter()
+    
+    // Subscribe to spell damage events
+    var damageCaptured int
+    eventBus.Subscribe(events.OnSpellDamage, &TestHandler{
+        onHandle: func(e interface{}) {
+            if dmgEvent, ok := e.(*events.DamageEvent); ok {
+                damageCaptured = dmgEvent.Damage
+            }
+        },
+    })
+    
+    // Cast vicious mockery
+    handler := &ViciousMockeryHandler{eventBus: eventBus}
+    result, err := handler.Execute(ctx, input)
+    
+    // Verify damage event was published
+    assert.NoError(t, err)
+    assert.Equal(t, expectedDamage, damageCaptured)
+}
+```

--- a/docs/rpg-toolkit-dnd5e-migration-plan.md
+++ b/docs/rpg-toolkit-dnd5e-migration-plan.md
@@ -1,0 +1,251 @@
+# rpg-toolkit D&D 5e Migration Plan
+
+## Goal: Complete Pure rpg-toolkit Implementation
+
+Replace the Discord bot's event system and D&D 5e logic with a comprehensive rpg-toolkit-based implementation that can power the full D&D 5e rulebook locally.
+
+## Current State Analysis
+
+### ✅ What Works in rpg-toolkit
+- **Event System**: Comprehensive event bus with proper entity/context support
+- **Basic Modifiers**: Attack bonus, damage bonus, advantage/disadvantage
+- **Entity System**: Clean Entity interface for characters/monsters
+- **Condition Foundation**: Basic condition interface exists
+
+### ❌ What's Missing in rpg-toolkit
+- **Proficiency System**: No proficiency bonus calculations or type checking
+- **Resource Management**: No spell slots, ability uses, hit dice tracking
+- **Equipment System**: No weapons, armor, or equipment properties
+- **Feature System**: No class/race features implementation
+- **Duration Tracking**: Limited compared to Discord bot's robust system
+- **Action Economy**: No action/bonus action/reaction tracking
+
+## Migration Strategy: 3 Phases
+
+### Phase 1: Foundation Systems (Current Sprint)
+Build the core D&D 5e systems that everything else depends on.
+
+#### 1.1 Proficiency System
+```go
+// Add to rpg-toolkit
+type ProficiencyType string
+const (
+    ProficiencyWeapon     ProficiencyType = "weapon"
+    ProficiencyArmor      ProficiencyType = "armor"
+    ProficiencySkill      ProficiencyType = "skill"
+    ProficiencySave       ProficiencyType = "saving_throw"
+    ProficiencyTool       ProficiencyType = "tool"
+)
+
+type Proficiency interface {
+    Type() ProficiencyType
+    Key() string
+    Name() string
+    Category() string // "simple-weapons", "martial-weapons", etc.
+}
+
+type ProficiencyManager interface {
+    HasProficiency(entity Entity, profType ProficiencyType, key string) bool
+    GetProficiencyBonus(entity Entity) int
+    AddProficiency(entity Entity, prof Proficiency)
+    RemoveProficiency(entity Entity, prof Proficiency)
+}
+```
+
+#### 1.2 Resource Management System
+```go
+type ResourceType string
+const (
+    ResourceSpellSlots ResourceType = "spell_slots"
+    ResourceHitDice    ResourceType = "hit_dice"
+    ResourceAbility    ResourceType = "ability_use"
+    ResourceAction     ResourceType = "action_economy"
+)
+
+type Resource interface {
+    Type() ResourceType
+    Key() string
+    Current() int
+    Maximum() int
+    Consume(amount int) error
+    Restore(amount int) error
+    RestoreToMax()
+}
+
+type ResourceManager interface {
+    GetResource(entity Entity, resourceType ResourceType, key string) Resource
+    AddResource(entity Entity, resource Resource)
+    ProcessShortRest(entity Entity)
+    ProcessLongRest(entity Entity)
+}
+```
+
+#### 1.3 Equipment System
+```go
+type EquipmentType string
+const (
+    EquipmentWeapon EquipmentType = "weapon"
+    EquipmentArmor  EquipmentType = "armor"
+    EquipmentItem   EquipmentType = "item"
+)
+
+type Equipment interface {
+    Type() EquipmentType
+    Key() string
+    Name() string
+    Properties() []string
+    IsEquipped() bool
+}
+
+type Weapon interface {
+    Equipment
+    AttackBonus(wielder Entity) int
+    DamageBonus(wielder Entity) int
+    DamageDice() string
+    IsFinesse() bool
+    IsVersatile() bool
+    IsTwoHanded() bool
+}
+
+type EquipmentManager interface {
+    GetEquippedWeapons(entity Entity) []Weapon
+    GetEquippedArmor(entity Entity) []Equipment
+    EquipItem(entity Entity, item Equipment) error
+    UnequipItem(entity Entity, item Equipment) error
+}
+```
+
+### Phase 2: Feature System (Next Sprint)
+Implement the D&D 5e class/race features that modify gameplay.
+
+#### 2.1 Feature System
+```go
+type FeatureType string
+const (
+    FeatureRacial    FeatureType = "racial"
+    FeatureClass     FeatureType = "class"
+    FeatureSubclass  FeatureType = "subclass"
+    FeatureFeat      FeatureType = "feat"
+)
+
+type Feature interface {
+    Type() FeatureType
+    Key() string
+    Name() string
+    Description() string
+    Level() int
+    Source() string
+    
+    // Feature behavior
+    IsPassive() bool
+    GetModifiers() []Modifier
+    GetEventListeners() []EventListener
+}
+
+type FeatureManager interface {
+    GetFeatures(entity Entity, featureType FeatureType) []Feature
+    AddFeature(entity Entity, feature Feature)
+    RemoveFeature(entity Entity, featureKey string)
+    ProcessLevelUp(entity Entity, newLevel int)
+}
+```
+
+#### 2.2 Migrate Core Features
+- **Rage**: Event-driven damage bonus and resistance
+- **Sneak Attack**: Conditional damage with usage tracking
+- **Bardic Inspiration**: Resource-based ability with action economy
+- **Spell Casting**: Spell slot management and casting mechanics
+
+### Phase 3: Advanced Mechanics (Final Sprint)
+Complete the D&D 5e implementation with advanced systems.
+
+#### 3.1 Condition System Enhancement
+```go
+type ConditionEffect interface {
+    Condition
+    GetModifiers() []Modifier
+    GetRestrictedActions() []ActionType
+    GetAutomaticFailures() []string
+    GetAutomaticSuccesses() []string
+}
+
+// Standard D&D 5e conditions
+var (
+    ConditionBlinded      = NewStandardCondition("blinded", /* modifiers */)
+    ConditionCharmed      = NewStandardCondition("charmed", /* modifiers */)
+    ConditionFrightened   = NewStandardCondition("frightened", /* modifiers */)
+    ConditionParalyzed    = NewStandardCondition("paralyzed", /* modifiers */)
+    ConditionPoisoned     = NewStandardCondition("poisoned", /* modifiers */)
+    ConditionProne        = NewStandardCondition("prone", /* modifiers */)
+    ConditionRestrained   = NewStandardCondition("restrained", /* modifiers */)
+    ConditionStunned      = NewStandardCondition("stunned", /* modifiers */)
+    ConditionUnconscious  = NewStandardCondition("unconscious", /* modifiers */)
+)
+```
+
+#### 3.2 Combat State Tracking
+```go
+type CombatState interface {
+    GetInitiativeOrder() []Entity
+    GetCurrentTurn() Entity
+    GetRoundNumber() int
+    AdvanceTurn()
+    AddCombatant(entity Entity, initiative int)
+    RemoveCombatant(entity Entity)
+}
+
+type ActionEconomy interface {
+    HasAction(entity Entity) bool
+    HasBonusAction(entity Entity) bool
+    HasReaction(entity Entity) bool
+    ConsumeAction(entity Entity, actionType ActionType) error
+    ResetTurn(entity Entity)
+}
+```
+
+## Implementation Approach
+
+### Step 1: Remove EventBusAdapter
+- Migrate all Discord bot listeners to use rpg-toolkit events directly
+- Remove the `EventBusAdapter` and conversion logic
+- Update all event emissions to use rpg-toolkit event types
+
+### Step 2: Build Foundation Systems
+- Implement ProficiencyManager in rpg-toolkit
+- Add ResourceManager for spell slots and abilities
+- Create basic EquipmentManager
+
+### Step 3: Migrate Features
+- Convert Rage to pure rpg-toolkit implementation
+- Convert SneakAttack to pure rpg-toolkit implementation
+- Convert ViciousMockery to pure rpg-toolkit implementation
+
+### Step 4: Test & Validate
+- Ensure all existing functionality still works
+- Add comprehensive integration tests
+- Validate performance (should be better without adapter overhead)
+
+## Benefits of Pure rpg-toolkit Approach
+
+1. **No Translation Bugs**: Eliminates context-loss bugs like we just fixed
+2. **Better Performance**: No event conversion overhead
+3. **Cleaner Architecture**: Single event system instead of dual system
+4. **rpg-toolkit Improvements**: Our D&D 5e implementation becomes reusable
+5. **Local Rulebook**: Full D&D 5e rules engine in rpg-toolkit
+
+## Files to Create
+
+### rpg-toolkit Extensions
+1. `proficiency/manager.go` - Proficiency system
+2. `resources/manager.go` - Resource management (spell slots, abilities)
+3. `equipment/manager.go` - Equipment and weapon system
+4. `features/manager.go` - Class/race feature system
+5. `conditions/dnd5e.go` - Standard D&D 5e conditions
+6. `combat/state.go` - Combat state and action economy
+
+### Migration Files
+1. `internal/adapters/rpgtoolkit/dnd5e/` - D&D 5e specific rpg-toolkit implementations
+2. Updated listeners in `internal/domain/rulebook/dnd5e/` to use pure rpg-toolkit
+3. Remove `internal/adapters/rpgtoolkit/event_bus.go` entirely
+
+This plan transforms the Discord bot from using rpg-toolkit as a library to making rpg-toolkit the authoritative D&D 5e rules engine.

--- a/docs/rpg-toolkit-extensions-needed.md
+++ b/docs/rpg-toolkit-extensions-needed.md
@@ -1,0 +1,339 @@
+# rpg-toolkit Extensions Needed for D&D 5e
+
+## Immediate Needs (Phase 1)
+
+Based on our analysis, here's what we need to add to rpg-toolkit to support feats, proficiencies, and conditions for a local D&D 5e rulebook implementation:
+
+### 1. Proficiency System 🎯
+
+**Why we need it**: Characters have proficiencies with weapons, armor, skills, and saving throws that provide bonuses.
+
+```go
+// Core proficiency types
+type ProficiencyType string
+const (
+    ProficiencyWeapon      ProficiencyType = "weapon"
+    ProficiencyArmor       ProficiencyType = "armor"
+    ProficiencySkill       ProficiencyType = "skill"
+    ProficiencySave        ProficiencyType = "saving_throw"
+    ProficiencyTool        ProficiencyType = "tool"
+    ProficiencyInstrument  ProficiencyType = "instrument"
+)
+
+// What we can be proficient with
+type Proficiency interface {
+    Type() ProficiencyType
+    Key() string           // "shortsword", "athletics", "constitution"
+    Name() string          // "Shortsword", "Athletics", "Constitution"
+    Category() string      // "simple-weapons", "martial-weapons", "strength-skills"
+}
+
+// Manages proficiencies for entities
+type ProficiencyManager interface {
+    // Check proficiency
+    HasProficiency(entity Entity, profType ProficiencyType, key string) bool
+    HasWeaponProficiency(entity Entity, weaponKey string) bool
+    HasSkillProficiency(entity Entity, skillKey string) bool
+    
+    // Get bonuses
+    GetProficiencyBonus(entity Entity) int // Based on level: +2, +3, +4, +5, +6
+    GetWeaponAttackBonus(entity Entity, weaponKey string) int
+    GetSkillBonus(entity Entity, skillKey string) int
+    GetSaveBonus(entity Entity, abilityKey string) int
+    
+    // Manage proficiencies
+    AddProficiency(entity Entity, prof Proficiency)
+    RemoveProficiency(entity Entity, profKey string)
+    GetAllProficiencies(entity Entity) []Proficiency
+}
+```
+
+**Real Examples**:
+- Rogue has proficiency with shortswords → +2 to attack rolls
+- Fighter has proficiency with Constitution saves → +2 to Constitution saving throws
+- Bard has proficiency with Performance skill → +2 to Performance checks
+
+### 2. Resource Management System ⚡
+
+**Why we need it**: Characters have limited-use abilities (spell slots, rage uses, bardic inspiration, etc.)
+
+```go
+type ResourceType string
+const (
+    ResourceSpellSlots   ResourceType = "spell_slots"
+    ResourceAbilityUses  ResourceType = "ability_uses"
+    ResourceHitDice      ResourceType = "hit_dice"
+    ResourceActionEcon   ResourceType = "action_economy"
+)
+
+type RestType string
+const (
+    RestTypeShort RestType = "short"
+    RestTypeLong  RestType = "long"
+)
+
+type Resource interface {
+    Type() ResourceType
+    Key() string        // "spell_slot_1", "rage_uses", "hit_dice_d10"
+    Name() string       // "1st Level Spell Slots", "Rage Uses"
+    Current() int       // Current available uses
+    Maximum() int       // Max uses at full resources
+    
+    // Resource management
+    CanConsume(amount int) bool
+    Consume(amount int) error
+    Restore(amount int) error
+    RestoreToMax()
+    
+    // Rest mechanics
+    RestoresOn() RestType  // Short rest, long rest, or both
+    RestoreAmount() int    // How much restores on rest
+}
+
+type ResourceManager interface {
+    // Get resources
+    GetResource(entity Entity, resourceType ResourceType, key string) Resource
+    GetSpellSlots(entity Entity, level int) Resource
+    GetAbilityUses(entity Entity, abilityKey string) Resource
+    
+    // Manage resources
+    AddResource(entity Entity, resource Resource)
+    RemoveResource(entity Entity, resourceKey string)
+    
+    // Rest mechanics
+    ProcessShortRest(entity Entity)
+    ProcessLongRest(entity Entity)
+    
+    // Usage tracking
+    ConsumeSpellSlot(entity Entity, level int) error
+    ConsumeAbilityUse(entity Entity, abilityKey string) error
+    RestoreResource(entity Entity, resourceKey string, amount int) error
+}
+```
+
+**Real Examples**:
+- Wizard has 2 first-level spell slots → can cast 2 first-level spells
+- Barbarian has 2 rage uses per long rest → can rage twice before needing long rest
+- Fighter has 1 Second Wind use per short rest → regains use after short rest
+
+### 3. Enhanced Condition System 🎭
+
+**Why we need it**: D&D 5e has standardized conditions that apply specific mechanical effects.
+
+```go
+// Enhanced condition with mechanical effects
+type EnhancedCondition interface {
+    Condition
+    
+    // Mechanical effects
+    GetModifiers() []Modifier
+    GetRestrictedActions() []ActionType
+    GetAutomaticFailures() []string    // "strength_saves", "dexterity_saves"
+    GetAutomaticSuccesses() []string
+    GetMovementRestrictions() MovementRestriction
+    
+    // Interaction rules
+    ConflictsWith() []string           // Conditions that remove this one
+    PreventsConditions() []string      // Conditions this prevents
+    UpgradesTo() map[string]string     // "restrained" -> "paralyzed"
+}
+
+// Standard D&D 5e conditions with proper mechanics
+var StandardConditions = map[string]EnhancedCondition{
+    "blinded": NewCondition("blinded").
+        WithModifiers(DisadvantageOn("attack_rolls")).
+        WithModifiers(AdvantageAgainst("attack_rolls")),
+        
+    "frightened": NewCondition("frightened").
+        WithModifiers(DisadvantageOn("ability_checks", "attack_rolls")).
+        WithMovementRestriction(CannotMoveTowardsSource()),
+        
+    "paralyzed": NewCondition("paralyzed").
+        WithRestrictedActions("move", "speak", "actions", "reactions").
+        WithAutomaticFailures("strength_saves", "dexterity_saves").
+        WithModifiers(AdvantageAgainst("attack_rolls")).
+        WithModifiers(AutoCriticalHitsWithin(5)),
+        
+    "poisoned": NewCondition("poisoned").
+        WithModifiers(DisadvantageOn("attack_rolls", "ability_checks")),
+        
+    "prone": NewCondition("prone").
+        WithModifiers(DisadvantageOn("attack_rolls")).
+        WithModifiers(AdvantageAgainst("melee_attacks")).
+        WithModifiers(DisadvantageAgainst("ranged_attacks")),
+}
+```
+
+**Real Examples**:
+- Poisoned creature has disadvantage on attack rolls and ability checks
+- Prone creature has disadvantage on attack rolls, advantage against melee attacks
+- Paralyzed creature auto-fails Strength and Dexterity saves, takes automatic crits
+
+### 4. Equipment & Weapon System ⚔️
+
+**Why we need it**: Equipment provides bonuses, properties, and determines proficiency requirements.
+
+```go
+type EquipmentSlot string
+const (
+    SlotMainHand   EquipmentSlot = "main_hand"
+    SlotOffHand    EquipmentSlot = "off_hand"
+    SlotArmor      EquipmentSlot = "armor"
+    SlotShield     EquipmentSlot = "shield"
+    SlotRing       EquipmentSlot = "ring"
+    SlotNecklace   EquipmentSlot = "necklace"
+)
+
+type WeaponProperty string
+const (
+    PropertyFinesse    WeaponProperty = "finesse"     // Can use DEX for attack/damage
+    PropertyVersatile  WeaponProperty = "versatile"   // 1d8 one-handed, 1d10 two-handed
+    PropertyTwoHanded  WeaponProperty = "two_handed"  // Requires two hands
+    PropertyLight      WeaponProperty = "light"       // Two-weapon fighting
+    PropertyHeavy      WeaponProperty = "heavy"       // Small creatures have disadvantage
+    PropertyReach      WeaponProperty = "reach"       // 10 ft reach instead of 5 ft
+    PropertyThrown     WeaponProperty = "thrown"      // Can be thrown
+)
+
+type Weapon interface {
+    Equipment
+    
+    // Attack properties
+    AttackBonus(wielder Entity) int
+    DamageBonus(wielder Entity) int
+    DamageDice() string              // "1d8", "1d6"
+    DamageType() string              // "slashing", "piercing", "bludgeoning"
+    
+    // Weapon properties
+    HasProperty(prop WeaponProperty) bool
+    IsFinesse() bool
+    IsVersatile() bool
+    GetVersatileDamage() string      // "1d10" for versatile weapons
+    
+    // Proficiency requirements
+    ProficiencyCategory() string     // "simple-weapons", "martial-weapons"
+    RequiresProficiency(wielder Entity) bool
+    
+    // Attack mechanics
+    CanUseAbilityScore(ability string) bool  // Finesse weapons can use DEX
+    GetAttackRange() int                     // 5 ft melee, varies for ranged
+}
+
+type EquipmentManager interface {
+    // Equipment management
+    EquipItem(entity Entity, item Equipment, slot EquipmentSlot) error
+    UnequipItem(entity Entity, slot EquipmentSlot) error
+    GetEquippedItem(entity Entity, slot EquipmentSlot) Equipment
+    
+    // Weapon-specific
+    GetMainHandWeapon(entity Entity) Weapon
+    GetOffHandWeapon(entity Entity) Weapon
+    CanDualWield(entity Entity) bool
+    
+    // AC calculation
+    GetArmorClass(entity Entity) int
+    GetArmorBonus(entity Entity) int
+    GetShieldBonus(entity Entity) int
+}
+```
+
+**Real Examples**:
+- Shortsword (finesse, light) → can use DEX for attacks, enables two-weapon fighting
+- Longsword (versatile) → 1d8 damage one-handed, 1d10 damage two-handed
+- Greataxe (heavy, two-handed) → requires two hands, small creatures have disadvantage
+
+### 5. Feature System 🌟
+
+**Why we need it**: Class and race features provide the core mechanical differences between characters.
+
+```go
+type FeatureType string
+const (
+    FeatureRacial    FeatureType = "racial"
+    FeatureClass     FeatureType = "class" 
+    FeatureSubclass  FeatureType = "subclass"
+    FeatureFeat      FeatureType = "feat"
+    FeatureItem      FeatureType = "item"
+)
+
+type FeatureTiming string
+const (
+    TimingPassive     FeatureTiming = "passive"      // Always active
+    TimingTriggered   FeatureTiming = "triggered"    // Reacts to events
+    TimingActivated   FeatureTiming = "activated"    // Player chooses to use
+)
+
+type Feature interface {
+    // Basic info
+    Key() string
+    Name() string
+    Description() string
+    Type() FeatureType
+    Level() int
+    Source() string
+    
+    // Mechanical effects
+    IsPassive() bool
+    GetTiming() FeatureTiming
+    GetModifiers() []Modifier
+    GetProficiencies() []Proficiency
+    GetResources() []Resource
+    
+    // Event integration
+    GetEventListeners() []EventListener
+    CanTrigger(event Event) bool
+    TriggerFeature(entity Entity, event Event) error
+    
+    // Prerequisites
+    HasPrerequisites() bool
+    MeetsPrerequisites(entity Entity) bool
+    GetPrerequisites() []string
+}
+
+// Examples of how features work
+var ExampleFeatures = map[string]Feature{
+    "rage": NewFeature("rage", FeatureClass).
+        WithResources(NewResource("rage_uses", 2, RestTypeLong)).
+        WithEventListeners(RageListener{}).
+        WithTiming(TimingActivated),
+        
+    "sneak_attack": NewFeature("sneak_attack", FeatureClass).
+        WithEventListeners(SneakAttackListener{}).
+        WithTiming(TimingTriggered),
+        
+    "darkvision": NewFeature("darkvision", FeatureRacial).
+        WithModifiers(VisionModifier("darkvision", 60)).
+        WithTiming(TimingPassive),
+}
+```
+
+**Real Examples**:
+- Rage (Barbarian class feature) → +2 damage, resistance to physical damage, limited uses
+- Sneak Attack (Rogue class feature) → Extra damage when conditions met
+- Darkvision (Half-orc racial feature) → See in darkness up to 60 feet
+
+## Integration Strategy
+
+### Step 1: Add to rpg-toolkit Core
+These systems should be added as core rpg-toolkit packages that any game system can use:
+- `proficiency/` - Generic proficiency system
+- `resources/` - Resource management and rest mechanics  
+- `equipment/` - Equipment slots and bonuses
+- `features/` - Feature system with event integration
+
+### Step 2: Create D&D 5e Rulebook Package
+Create a D&D 5e specific package that uses the core systems:
+- `dnd5e/proficiencies.go` - All D&D 5e proficiencies
+- `dnd5e/conditions.go` - All D&D 5e conditions with proper mechanics
+- `dnd5e/equipment.go` - D&D 5e weapons and armor
+- `dnd5e/features.go` - All class/race features
+- `dnd5e/spells.go` - Spell implementations
+
+### Step 3: Replace Discord Bot Systems
+Migrate the Discord bot to use the rpg-toolkit D&D 5e implementation:
+- Remove EventBusAdapter entirely
+- Convert all listeners to use rpg-toolkit events
+- Use rpg-toolkit proficiency/resource/equipment managers
+- Replace character features with rpg-toolkit feature system
+
+This creates a comprehensive, reusable D&D 5e rules engine in rpg-toolkit that can power not just our Discord bot, but any D&D 5e application.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.1.1-0.20250704020020-1ad05ac94e2b
-	github.com/KirkDiggler/rpg-toolkit/events v0.1.2-0.20250704015839-a9a025dddbb0
+	github.com/KirkDiggler/rpg-toolkit/events v0.1.2-0.20250704020020-1ad05ac94e2b
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/fadedpez/dnd5e-api v0.0.0-20250702035924-9fa22aaeef04
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/KirkDiggler/dnd-bot-discord
 
-go 1.23.2
+go 1.24.1
 
 require (
+	github.com/KirkDiggler/rpg-toolkit/core v0.1.1-0.20250704020020-1ad05ac94e2b
+	github.com/KirkDiggler/rpg-toolkit/events v0.1.2-0.20250704015839-a9a025dddbb0
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/fadedpez/dnd5e-api v0.0.0-20250702035924-9fa22aaeef04
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/KirkDiggler/rpg-toolkit/core v0.1.1-0.20250704020020-1ad05ac94e2b h1:av8oZztjMXy31/iSNcYLwGDzy9yVJ6ALTWtIOLuiyMQ=
 github.com/KirkDiggler/rpg-toolkit/core v0.1.1-0.20250704020020-1ad05ac94e2b/go.mod h1:N7xIvJGjmrHHNjfWQ3O1LlkalzImcMav3O0fNOg+8No=
-github.com/KirkDiggler/rpg-toolkit/events v0.1.2-0.20250704015839-a9a025dddbb0 h1:6vrgWFv2qsj1bujAmLbFVWtGV5qD0qxGo1gYyWKGycc=
-github.com/KirkDiggler/rpg-toolkit/events v0.1.2-0.20250704015839-a9a025dddbb0/go.mod h1:M+mF5gE04daLz73PX173IOn0CmVoAC6ff10Kx3BBCe8=
+github.com/KirkDiggler/rpg-toolkit/events v0.1.2-0.20250704020020-1ad05ac94e2b h1:jcVjTUTeC3TSJcpemW93tcbndQQN9mBV8VXfXkPZ7MQ=
+github.com/KirkDiggler/rpg-toolkit/events v0.1.2-0.20250704020020-1ad05ac94e2b/go.mod h1:M+mF5gE04daLz73PX173IOn0CmVoAC6ff10Kx3BBCe8=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/KirkDiggler/rpg-toolkit/core v0.1.1-0.20250704020020-1ad05ac94e2b h1:av8oZztjMXy31/iSNcYLwGDzy9yVJ6ALTWtIOLuiyMQ=
+github.com/KirkDiggler/rpg-toolkit/core v0.1.1-0.20250704020020-1ad05ac94e2b/go.mod h1:N7xIvJGjmrHHNjfWQ3O1LlkalzImcMav3O0fNOg+8No=
+github.com/KirkDiggler/rpg-toolkit/events v0.1.2-0.20250704015839-a9a025dddbb0 h1:6vrgWFv2qsj1bujAmLbFVWtGV5qD0qxGo1gYyWKGycc=
+github.com/KirkDiggler/rpg-toolkit/events v0.1.2-0.20250704015839-a9a025dddbb0/go.mod h1:M+mF5gE04daLz73PX173IOn0CmVoAC6ff10Kx3BBCe8=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=

--- a/internal/adapters/rpgtoolkit/entities.go
+++ b/internal/adapters/rpgtoolkit/entities.go
@@ -21,7 +21,7 @@ func (c *CharacterEntityAdapter) GetID() string {
 	if c.Character == nil {
 		return ""
 	}
-	return c.Character.ID
+	return c.ID
 }
 
 // GetType returns the entity type

--- a/internal/adapters/rpgtoolkit/entities.go
+++ b/internal/adapters/rpgtoolkit/entities.go
@@ -1,0 +1,60 @@
+package rpgtoolkit
+
+import (
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
+// EntityAdapter provides a common interface for adapting Discord bot entities
+// to rpg-toolkit's core.Entity interface
+type EntityAdapter interface {
+	core.Entity
+}
+
+// CharacterEntityAdapter adapts a Discord bot Character to rpg-toolkit's Entity interface
+type CharacterEntityAdapter struct {
+	*character.Character
+}
+
+// GetID returns the character's ID
+func (c *CharacterEntityAdapter) GetID() string {
+	if c.Character == nil {
+		return ""
+	}
+	return c.Character.ID
+}
+
+// GetType returns the entity type
+func (c *CharacterEntityAdapter) GetType() string {
+	return "character"
+}
+
+// MonsterEntityAdapter adapts a monster/NPC to rpg-toolkit's Entity interface
+type MonsterEntityAdapter struct {
+	ID   string
+	Name string
+}
+
+// GetID returns the monster's ID
+func (m *MonsterEntityAdapter) GetID() string {
+	return m.ID
+}
+
+// GetType returns the entity type
+func (m *MonsterEntityAdapter) GetType() string {
+	return "monster"
+}
+
+// CreateEntityAdapter creates an appropriate adapter based on the input type
+func CreateEntityAdapter(entity interface{}) EntityAdapter {
+	switch e := entity.(type) {
+	case *character.Character:
+		return &CharacterEntityAdapter{Character: e}
+	case character.Character:
+		return &CharacterEntityAdapter{Character: &e}
+	default:
+		// For now, return nil for unknown types
+		// In the future, we might want to handle more entity types
+		return nil
+	}
+}

--- a/internal/adapters/rpgtoolkit/entities.go
+++ b/internal/adapters/rpgtoolkit/entities.go
@@ -2,6 +2,7 @@ package rpgtoolkit
 
 import (
 	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/game/combat"
 	"github.com/KirkDiggler/rpg-toolkit/core"
 )
 
@@ -29,14 +30,16 @@ func (c *CharacterEntityAdapter) GetType() string {
 	return "character"
 }
 
-// MonsterEntityAdapter adapts a monster/NPC to rpg-toolkit's Entity interface
+// MonsterEntityAdapter adapts a combat monster to rpg-toolkit's Entity interface
 type MonsterEntityAdapter struct {
-	ID   string
-	Name string
+	*combat.Combatant
 }
 
 // GetID returns the monster's ID
 func (m *MonsterEntityAdapter) GetID() string {
+	if m.Combatant == nil {
+		return ""
+	}
 	return m.ID
 }
 
@@ -52,6 +55,10 @@ func CreateEntityAdapter(entity interface{}) EntityAdapter {
 		return &CharacterEntityAdapter{Character: e}
 	case character.Character:
 		return &CharacterEntityAdapter{Character: &e}
+	case *combat.Combatant:
+		return &MonsterEntityAdapter{Combatant: e}
+	case combat.Combatant:
+		return &MonsterEntityAdapter{Combatant: &e}
 	default:
 		// For now, return nil for unknown types
 		// In the future, we might want to handle more entity types

--- a/internal/adapters/rpgtoolkit/event_bus.go
+++ b/internal/adapters/rpgtoolkit/event_bus.go
@@ -1,0 +1,194 @@
+package rpgtoolkit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/events"
+	rpgevents "github.com/KirkDiggler/rpg-toolkit/events"
+)
+
+// EventBusAdapter wraps rpg-toolkit's event bus to provide compatibility
+// with the Discord bot's existing event system
+type EventBusAdapter struct {
+	rpgBus *rpgevents.Bus
+	// Maps Discord bot event types to rpg-toolkit event types
+	eventTypeMap map[events.EventType]string
+	// Maps rpg-toolkit event types back to Discord bot types
+	reverseMap map[string]events.EventType
+}
+
+// NewEventBusAdapter creates a new adapter wrapping an rpg-toolkit event bus
+func NewEventBusAdapter() *EventBusAdapter {
+	adapter := &EventBusAdapter{
+		rpgBus:       rpgevents.NewBus(),
+		eventTypeMap: make(map[events.EventType]string),
+		reverseMap:   make(map[string]events.EventType),
+	}
+
+	// Set up event type mappings
+	adapter.setupEventMappings()
+
+	return adapter
+}
+
+// setupEventMappings configures the bidirectional mapping between event systems
+func (a *EventBusAdapter) setupEventMappings() {
+	mappings := map[events.EventType]string{
+		events.BeforeAttackRoll:  rpgevents.EventBeforeAttackRoll,
+		events.OnAttackRoll:      rpgevents.EventOnAttackRoll,
+		events.AfterAttackRoll:   rpgevents.EventAfterAttackRoll,
+		events.BeforeDamageRoll:  rpgevents.EventBeforeDamageRoll,
+		events.OnDamageRoll:      rpgevents.EventOnDamageRoll,
+		events.AfterDamageRoll:   rpgevents.EventAfterDamageRoll,
+		events.BeforeTakeDamage:  rpgevents.EventBeforeTakeDamage,
+		events.OnTakeDamage:      rpgevents.EventOnTakeDamage,
+		events.AfterTakeDamage:   rpgevents.EventAfterTakeDamage,
+		events.BeforeSavingThrow: rpgevents.EventBeforeSavingThrow,
+		events.OnSavingThrow:     rpgevents.EventOnSavingThrow,
+		events.AfterSavingThrow:  rpgevents.EventAfterSavingThrow,
+		events.OnTurnStart:       rpgevents.EventOnTurnStart,
+		events.OnTurnEnd:         rpgevents.EventOnTurnEnd,
+		events.OnStatusApplied:   rpgevents.EventOnConditionApplied,
+		events.OnStatusRemoved:   rpgevents.EventOnConditionRemoved,
+		events.OnShortRest:       rpgevents.EventOnShortRest,
+		events.OnLongRest:        rpgevents.EventOnLongRest,
+		events.OnSpellCast:       rpgevents.EventOnSpellCast,
+		events.OnSpellDamage:     rpgevents.EventOnSpellDamage,
+	}
+
+	for discordType, rpgType := range mappings {
+		a.eventTypeMap[discordType] = rpgType
+		a.reverseMap[rpgType] = discordType
+	}
+}
+
+// Publish publishes an event to the rpg-toolkit event bus
+func (a *EventBusAdapter) Publish(eventType events.EventType, data interface{}) error {
+	rpgEventType, ok := a.eventTypeMap[eventType]
+	if !ok {
+		return fmt.Errorf("unknown event type: %v", eventType)
+	}
+
+	// Convert the data to an rpg-toolkit event
+	gameEvent := a.createGameEvent(rpgEventType, data)
+
+	return a.rpgBus.Publish(context.Background(), gameEvent)
+}
+
+// Subscribe registers a listener for a specific event type
+func (a *EventBusAdapter) Subscribe(eventType events.EventType, listener events.EventListener) {
+	rpgEventType, ok := a.eventTypeMap[eventType]
+	if !ok {
+		// Log warning about unknown event type
+		return
+	}
+
+	// Wrap the listener to convert rpg-toolkit events back to Discord format
+	wrappedHandler := a.wrapHandler(listener, eventType)
+
+	// Use the listener's priority
+	a.rpgBus.SubscribeFunc(rpgEventType, listener.Priority(), wrappedHandler)
+}
+
+// createGameEvent converts Discord bot event data to rpg-toolkit GameEvent
+func (a *EventBusAdapter) createGameEvent(eventType string, data interface{}) rpgevents.Event {
+	// Extract source and target based on the data type
+	var source, target EntityAdapter
+
+	switch d := data.(type) {
+	case *events.GameEvent:
+		if d.Actor != nil {
+			source = &CharacterEntityAdapter{Character: d.Actor}
+		}
+		if d.Target != nil {
+			target = &CharacterEntityAdapter{Character: d.Target}
+		}
+
+		event := rpgevents.NewGameEvent(eventType, source, target)
+
+		// Copy context data
+		for k, v := range d.Context {
+			event.Context().Set(k, v)
+		}
+
+		// Handle cancellation
+		if d.Cancelled {
+			event.Cancel()
+		}
+
+		return event
+
+	default:
+		// For other data types, create a simple event
+		event := rpgevents.NewGameEvent(eventType, nil, nil)
+
+		// Store the entire data object in context
+		event.Context().Set("data", data)
+
+		return event
+	}
+}
+
+// wrapHandler wraps a Discord bot event listener to work with rpg-toolkit events
+func (a *EventBusAdapter) wrapHandler(listener events.EventListener, expectedType events.EventType) func(context.Context, rpgevents.Event) error {
+	return func(ctx context.Context, e rpgevents.Event) error {
+		// Convert rpg-toolkit event back to Discord bot format
+		gameEvent := a.convertToGameEvent(e, expectedType)
+		if gameEvent == nil {
+			return nil
+		}
+
+		// Call the original listener
+		return listener.HandleEvent(gameEvent)
+	}
+}
+
+// convertToGameEvent converts an rpg-toolkit event to Discord bot GameEvent
+func (a *EventBusAdapter) convertToGameEvent(rpgEvent rpgevents.Event, eventType events.EventType) *events.GameEvent {
+	// Get the reverse mapped event type
+	discordType, ok := a.reverseMap[rpgEvent.Type()]
+	if !ok {
+		discordType = eventType // fallback to expected type
+	}
+
+	// Create GameEvent with basic fields
+	gameEvent := &events.GameEvent{
+		Type:      discordType,
+		Context:   make(map[string]interface{}),
+		Cancelled: rpgEvent.IsCancelled(),
+	}
+
+	// Convert entities to characters if possible
+	if source := rpgEvent.Source(); source != nil {
+		if adapter, ok := source.(*CharacterEntityAdapter); ok {
+			gameEvent.Actor = adapter.Character
+		}
+	}
+	if target := rpgEvent.Target(); target != nil {
+		if adapter, ok := target.(*CharacterEntityAdapter); ok {
+			gameEvent.Target = adapter.Character
+		}
+	}
+
+	// Copy context data
+	ctx := rpgEvent.Context()
+	// We would need to iterate through context data
+	// For now, copy specific known fields
+	if weapon, ok := ctx.Get("weapon"); ok {
+		gameEvent.Context["weapon"] = weapon
+	}
+	if damage, ok := ctx.Get("damage"); ok {
+		gameEvent.Context["damage"] = damage
+	}
+	if damageType, ok := ctx.Get("damage_type"); ok {
+		gameEvent.Context["damage_type"] = damageType
+	}
+
+	return gameEvent
+}
+
+// GetRPGBus returns the underlying rpg-toolkit event bus for direct access
+func (a *EventBusAdapter) GetRPGBus() *rpgevents.Bus {
+	return a.rpgBus
+}

--- a/internal/adapters/rpgtoolkit/event_bus.go
+++ b/internal/adapters/rpgtoolkit/event_bus.go
@@ -192,18 +192,20 @@ func (a *EventBusAdapter) convertToGameEvent(rpgEvent rpgevents.Event, eventType
 		}
 	}
 
-	// Copy context data
+	// Copy context data - iterate through all context fields
 	ctx := rpgEvent.Context()
-	// We would need to iterate through context data
-	// For now, copy specific known fields
-	if weapon, ok := ctx.Get("weapon"); ok {
-		gameEvent.Context["weapon"] = weapon
+	// TODO: The rpg-toolkit Context interface doesn't expose a way to iterate all keys
+	// For now, copy all known fields that might be used
+	knownFields := []string{
+		"weapon", "damage", "damage_type", "target_id", "effect_name",
+		"effect_duration", "effect_type", "encounter_id", "user_id",
+		"spell_name", "caster_id", "damage_amount",
 	}
-	if damage, ok := ctx.Get("damage"); ok {
-		gameEvent.Context["damage"] = damage
-	}
-	if damageType, ok := ctx.Get("damage_type"); ok {
-		gameEvent.Context["damage_type"] = damageType
+
+	for _, field := range knownFields {
+		if value, ok := ctx.Get(field); ok {
+			gameEvent.Context[field] = value
+		}
 	}
 
 	return gameEvent

--- a/internal/domain/events/interface.go
+++ b/internal/domain/events/interface.go
@@ -1,0 +1,19 @@
+package events
+
+// Bus is the interface for event bus implementations
+type Bus interface {
+	// Subscribe adds a listener for a specific event type
+	Subscribe(eventType EventType, listener EventListener)
+
+	// Unsubscribe removes a listener for a specific event type
+	Unsubscribe(eventType EventType, listener EventListener)
+
+	// Emit sends an event to all registered listeners
+	Emit(event *GameEvent) error
+
+	// Clear removes all listeners
+	Clear()
+
+	// ListenerCount returns the number of listeners for an event type
+	ListenerCount(eventType EventType) int
+}

--- a/internal/domain/game/combat/encounter.go
+++ b/internal/domain/game/combat/encounter.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/shared"
 )
 
 // EncounterStatus represents the current state of an encounter
@@ -73,6 +75,9 @@ type Combatant struct {
 	XP         int              `json:"xp,omitempty"`          // Experience Points
 	Abilities  map[string]int   `json:"abilities,omitempty"`   // STR, DEX, etc.
 	Actions    []*MonsterAction `json:"actions,omitempty"`     // Available actions
+
+	// Temporary effects (for both players and monsters)
+	ActiveEffects []*shared.ActiveEffect `json:"active_effects,omitempty"` // Temporary combat effects
 }
 
 // IsAlive returns true if the combatant has more than 0 HP

--- a/internal/domain/rulebook/dnd5e/abilities/rage.go
+++ b/internal/domain/rulebook/dnd5e/abilities/rage.go
@@ -15,7 +15,7 @@ import (
 
 // RageHandler implements the barbarian rage ability
 type RageHandler struct {
-	eventBus         *events.EventBus
+	eventBus         events.Bus
 	encounterService interface {
 		GetEncounter(ctx context.Context, id string) (*Encounter, error)
 	}
@@ -33,7 +33,7 @@ type Encounter struct {
 }
 
 // NewRageHandler creates a new rage handler
-func NewRageHandler(eventBus *events.EventBus) *RageHandler {
+func NewRageHandler(eventBus events.Bus) *RageHandler {
 	return &RageHandler{
 		eventBus:        eventBus,
 		activeListeners: make(map[string]events.EventListener),

--- a/internal/domain/rulebook/dnd5e/abilities/registry.go
+++ b/internal/domain/rulebook/dnd5e/abilities/registry.go
@@ -9,7 +9,7 @@ import (
 
 // RegistryConfig contains dependencies needed for ability handlers
 type RegistryConfig struct {
-	EventBus         *events.EventBus
+	EventBus         events.Bus     // Now using the interface
 	RPGEventBus      *rpgevents.Bus // RPG toolkit event bus for future migration
 	DiceRoller       dice.Roller
 	EncounterService interface{} // Should have GetEncounter method

--- a/internal/domain/rulebook/dnd5e/abilities/registry.go
+++ b/internal/domain/rulebook/dnd5e/abilities/registry.go
@@ -4,11 +4,13 @@ import (
 	"github.com/KirkDiggler/dnd-bot-discord/internal/dice"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/events"
 	abilityService "github.com/KirkDiggler/dnd-bot-discord/internal/services/ability"
+	rpgevents "github.com/KirkDiggler/rpg-toolkit/events"
 )
 
 // RegistryConfig contains dependencies needed for ability handlers
 type RegistryConfig struct {
 	EventBus         *events.EventBus
+	RPGEventBus      *rpgevents.Bus // RPG toolkit event bus for future migration
 	DiceRoller       dice.Roller
 	EncounterService interface{} // Should have GetEncounter method
 	CharacterService interface{} // Should have UpdateEquipment method
@@ -45,12 +47,5 @@ func RegisterAll(registry interface {
 	registry.RegisterHandler(NewServiceHandlerAdapter(divineSenseHandler))
 
 	// Register vicious mockery (bard cantrip)
-	viciousMockeryHandler := NewViciousMockeryHandler(cfg.EventBus)
-	if cfg.DiceRoller != nil {
-		viciousMockeryHandler.SetDiceRoller(cfg.DiceRoller)
-	}
-	if cfg.CharacterService != nil {
-		viciousMockeryHandler.SetCharacterService(cfg.CharacterService)
-	}
-	registry.RegisterHandler(NewServiceHandlerAdapter(viciousMockeryHandler))
+	RegisterViciousMockeryHandler(registry, cfg)
 }

--- a/internal/domain/rulebook/dnd5e/abilities/sneak_attack.go
+++ b/internal/domain/rulebook/dnd5e/abilities/sneak_attack.go
@@ -13,7 +13,7 @@ import (
 
 // SneakAttackHandler implements the rogue sneak attack ability
 type SneakAttackHandler struct {
-	eventBus   *events.EventBus
+	eventBus   events.Bus
 	diceRoller interface {
 		Roll(numDice, sides, modifier int) (struct{ Total int }, error)
 	}
@@ -27,7 +27,7 @@ type SneakAttackHandler struct {
 }
 
 // NewSneakAttackHandler creates a new sneak attack handler
-func NewSneakAttackHandler(eventBus *events.EventBus) *SneakAttackHandler {
+func NewSneakAttackHandler(eventBus events.Bus) *SneakAttackHandler {
 	return &SneakAttackHandler{
 		eventBus:        eventBus,
 		activeListeners: make(map[string]events.EventListener),

--- a/internal/domain/rulebook/dnd5e/abilities/vicious_mockery.go
+++ b/internal/domain/rulebook/dnd5e/abilities/vicious_mockery.go
@@ -16,7 +16,7 @@ type ViciousMockeryHandler struct {
 }
 
 // NewViciousMockeryHandler creates a new vicious mockery ability handler
-func NewViciousMockeryHandler(eventBus *events.EventBus) *ViciousMockeryHandler {
+func NewViciousMockeryHandler(eventBus events.Bus) *ViciousMockeryHandler {
 	return &ViciousMockeryHandler{
 		spellHandler: spells.NewViciousMockeryHandler(eventBus),
 	}

--- a/internal/domain/rulebook/dnd5e/abilities/vicious_mockery_rpg.go
+++ b/internal/domain/rulebook/dnd5e/abilities/vicious_mockery_rpg.go
@@ -47,10 +47,12 @@ func (v *ViciousMockeryRPGListener) handleBeforeAttackRoll(ctx context.Context, 
 
 	// Check if character has vicious mockery effect
 	hasViciousMockery := false
-	for _, effect := range char.Resources.ActiveEffects {
-		if effect.Name == "Vicious Mockery Disadvantage" && !effect.IsExpired() {
-			hasViciousMockery = true
-			break
+	if char.Resources != nil && char.Resources.ActiveEffects != nil {
+		for _, effect := range char.Resources.ActiveEffects {
+			if effect.Name == "Vicious Mockery Disadvantage" && !effect.IsExpired() {
+				hasViciousMockery = true
+				break
+			}
 		}
 	}
 
@@ -66,13 +68,15 @@ func (v *ViciousMockeryRPGListener) handleBeforeAttackRoll(ctx context.Context, 
 		log.Printf("Applied disadvantage from Vicious Mockery to %s's attack", char.Name)
 
 		// Remove the effect after it's used (it only affects the next attack)
-		newEffects := []*shared.ActiveEffect{}
-		for _, effect := range char.Resources.ActiveEffects {
-			if effect.Name != "Vicious Mockery Disadvantage" {
-				newEffects = append(newEffects, effect)
+		if char.Resources != nil && char.Resources.ActiveEffects != nil {
+			newEffects := []*shared.ActiveEffect{}
+			for _, effect := range char.Resources.ActiveEffects {
+				if effect.Name != "Vicious Mockery Disadvantage" {
+					newEffects = append(newEffects, effect)
+				}
 			}
+			char.Resources.ActiveEffects = newEffects
 		}
-		char.Resources.ActiveEffects = newEffects
 	}
 
 	return nil

--- a/internal/domain/rulebook/dnd5e/abilities/vicious_mockery_rpg.go
+++ b/internal/domain/rulebook/dnd5e/abilities/vicious_mockery_rpg.go
@@ -2,7 +2,6 @@ package abilities
 
 import (
 	"context"
-	"log"
 
 	"github.com/KirkDiggler/dnd-bot-discord/internal/adapters/rpgtoolkit"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/shared"
@@ -39,7 +38,6 @@ func (v *ViciousMockeryRPGListener) handleBeforeAttackRoll(ctx context.Context, 
 
 	// Check if this is an entity with vicious mockery effect
 	var hasViciousMockery bool
-	var entityName string
 
 	switch adapter := attacker.(type) {
 	case *rpgtoolkit.CharacterEntityAdapter:
@@ -47,7 +45,6 @@ func (v *ViciousMockeryRPGListener) handleBeforeAttackRoll(ctx context.Context, 
 		if adapter.Character == nil {
 			return nil
 		}
-		entityName = adapter.Name
 
 		if adapter.Resources != nil && adapter.Resources.ActiveEffects != nil {
 			for _, effect := range adapter.Resources.ActiveEffects {
@@ -63,7 +60,6 @@ func (v *ViciousMockeryRPGListener) handleBeforeAttackRoll(ctx context.Context, 
 		if adapter.Combatant == nil {
 			return nil
 		}
-		entityName = adapter.Name
 
 		if adapter.ActiveEffects != nil {
 			for _, effect := range adapter.ActiveEffects {
@@ -88,7 +84,7 @@ func (v *ViciousMockeryRPGListener) handleBeforeAttackRoll(ctx context.Context, 
 			100,                   // High priority to ensure it's applied
 		))
 
-		log.Printf("Applied disadvantage from Vicious Mockery to %s's attack", entityName)
+		// Applied disadvantage from Vicious Mockery (removed excessive logging)
 
 		// Remove the effect after it's used (it only affects the next attack)
 		switch adapter := attacker.(type) {

--- a/internal/domain/rulebook/dnd5e/abilities/vicious_mockery_rpg.go
+++ b/internal/domain/rulebook/dnd5e/abilities/vicious_mockery_rpg.go
@@ -1,0 +1,99 @@
+package abilities
+
+import (
+	"context"
+	"log"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/adapters/rpgtoolkit"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/shared"
+	abilityService "github.com/KirkDiggler/dnd-bot-discord/internal/services/ability"
+	rpgevents "github.com/KirkDiggler/rpg-toolkit/events"
+)
+
+// ViciousMockeryRPGListener listens for attack roll events and applies disadvantage
+type ViciousMockeryRPGListener struct {
+	rpgBus *rpgevents.Bus
+}
+
+// NewViciousMockeryRPGListener creates a new listener for vicious mockery effects
+func NewViciousMockeryRPGListener(rpgBus *rpgevents.Bus) *ViciousMockeryRPGListener {
+	listener := &ViciousMockeryRPGListener{
+		rpgBus: rpgBus,
+	}
+
+	// Subscribe to attack roll events to apply disadvantage
+	if rpgBus != nil {
+		rpgBus.SubscribeFunc(rpgevents.EventBeforeAttackRoll, 10, listener.handleBeforeAttackRoll)
+	}
+
+	return listener
+}
+
+// handleBeforeAttackRoll checks if the attacker has vicious mockery disadvantage
+func (v *ViciousMockeryRPGListener) handleBeforeAttackRoll(ctx context.Context, event rpgevents.Event) error {
+	// Get the attacker
+	attacker := event.Source()
+	if attacker == nil {
+		return nil
+	}
+
+	// Check if this is a character with vicious mockery effect
+	charAdapter, ok := attacker.(*rpgtoolkit.CharacterEntityAdapter)
+	if !ok || charAdapter.Character == nil {
+		return nil
+	}
+
+	char := charAdapter.Character
+
+	// Check if character has vicious mockery effect
+	hasViciousMockery := false
+	for _, effect := range char.Resources.ActiveEffects {
+		if effect.Name == "Vicious Mockery Disadvantage" && !effect.IsExpired() {
+			hasViciousMockery = true
+			break
+		}
+	}
+
+	if hasViciousMockery {
+		// Add disadvantage modifier to the event
+		event.Context().AddModifier(rpgevents.NewModifier(
+			"vicious_mockery",
+			rpgevents.ModifierDisadvantage,
+			rpgevents.IntValue(1), // 1 = has disadvantage
+			100,                   // High priority to ensure it's applied
+		))
+
+		log.Printf("Applied disadvantage from Vicious Mockery to %s's attack", char.Name)
+
+		// Remove the effect after it's used (it only affects the next attack)
+		newEffects := []*shared.ActiveEffect{}
+		for _, effect := range char.Resources.ActiveEffects {
+			if effect.Name != "Vicious Mockery Disadvantage" {
+				newEffects = append(newEffects, effect)
+			}
+		}
+		char.Resources.ActiveEffects = newEffects
+	}
+
+	return nil
+}
+
+// RegisterViciousMockeryHandler updates the registration to include RPG event listener
+func RegisterViciousMockeryHandler(registry interface {
+	RegisterHandler(handler abilityService.Handler)
+}, cfg *RegistryConfig) {
+	// Register the traditional handler
+	viciousMockeryHandler := NewViciousMockeryHandler(cfg.EventBus)
+	if cfg.DiceRoller != nil {
+		viciousMockeryHandler.SetDiceRoller(cfg.DiceRoller)
+	}
+	if cfg.CharacterService != nil {
+		viciousMockeryHandler.SetCharacterService(cfg.CharacterService)
+	}
+	registry.RegisterHandler(NewServiceHandlerAdapter(viciousMockeryHandler))
+
+	// Also create the RPG event listener if we have an RPG event bus
+	if cfg.RPGEventBus != nil {
+		NewViciousMockeryRPGListener(cfg.RPGEventBus)
+	}
+}

--- a/internal/domain/rulebook/dnd5e/abilities/vicious_mockery_rpg_test.go
+++ b/internal/domain/rulebook/dnd5e/abilities/vicious_mockery_rpg_test.go
@@ -1,0 +1,141 @@
+package abilities
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KirkDiggler/dnd-bot-discord/internal/adapters/rpgtoolkit"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/shared"
+	rpgevents "github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestViciousMockeryRPGListener(t *testing.T) {
+	t.Run("applies disadvantage to attack roll", func(t *testing.T) {
+		// Create RPG event bus
+		rpgBus := rpgevents.NewBus()
+
+		// Create listener
+		listener := NewViciousMockeryRPGListener(rpgBus)
+		require.NotNil(t, listener)
+
+		// Create a character with vicious mockery effect
+		char := &character.Character{
+			ID:   "test-char",
+			Name: "Test Character",
+			Resources: &character.CharacterResources{
+				ActiveEffects: []*shared.ActiveEffect{
+					{
+						Name:         "Vicious Mockery Disadvantage",
+						Description:  "Disadvantage on next attack roll",
+						Source:       "Vicious Mockery",
+						Duration:     1,
+						DurationType: shared.DurationTypeRounds,
+					},
+				},
+			},
+		}
+
+		// Create attack roll event
+		attackEvent := rpgevents.NewGameEvent(
+			rpgevents.EventBeforeAttackRoll,
+			&rpgtoolkit.CharacterEntityAdapter{Character: char},
+			nil,
+		)
+
+		// Emit the event
+		err := rpgBus.Publish(context.Background(), attackEvent)
+		require.NoError(t, err)
+
+		// Check that disadvantage modifier was added
+		modifiers := attackEvent.Context().Modifiers()
+		require.Len(t, modifiers, 1)
+
+		modifier := modifiers[0]
+		assert.Equal(t, "vicious_mockery", modifier.Source())
+		assert.Equal(t, rpgevents.ModifierDisadvantage, modifier.Type())
+		assert.Equal(t, 1, modifier.ModifierValue().GetValue())
+
+		// Check that the effect was removed after use
+		assert.Empty(t, char.Resources.ActiveEffects)
+	})
+
+	t.Run("ignores characters without vicious mockery", func(t *testing.T) {
+		// Create RPG event bus
+		rpgBus := rpgevents.NewBus()
+
+		// Create listener
+		NewViciousMockeryRPGListener(rpgBus)
+
+		// Create a character without vicious mockery effect
+		char := &character.Character{
+			ID:        "test-char",
+			Name:      "Test Character",
+			Resources: &character.CharacterResources{},
+		}
+
+		// Create attack roll event
+		attackEvent := rpgevents.NewGameEvent(
+			rpgevents.EventBeforeAttackRoll,
+			&rpgtoolkit.CharacterEntityAdapter{Character: char},
+			nil,
+		)
+
+		// Emit the event
+		err := rpgBus.Publish(context.Background(), attackEvent)
+		require.NoError(t, err)
+
+		// Check that no modifiers were added
+		modifiers := attackEvent.Context().Modifiers()
+		assert.Empty(t, modifiers)
+	})
+
+	t.Run("only removes vicious mockery effect", func(t *testing.T) {
+		// Create RPG event bus
+		rpgBus := rpgevents.NewBus()
+
+		// Create listener
+		NewViciousMockeryRPGListener(rpgBus)
+
+		// Create a character with multiple effects
+		char := &character.Character{
+			ID:   "test-char",
+			Name: "Test Character",
+			Resources: &character.CharacterResources{
+				ActiveEffects: []*shared.ActiveEffect{
+					{
+						Name:         "Vicious Mockery Disadvantage",
+						Description:  "Disadvantage on next attack roll",
+						Source:       "Vicious Mockery",
+						Duration:     1,
+						DurationType: shared.DurationTypeRounds,
+					},
+					{
+						Name:         "Bless",
+						Description:  "+1d4 to attack rolls",
+						Source:       "Bless",
+						Duration:     10,
+						DurationType: shared.DurationTypeMinutes,
+					},
+				},
+			},
+		}
+
+		// Create attack roll event
+		attackEvent := rpgevents.NewGameEvent(
+			rpgevents.EventBeforeAttackRoll,
+			&rpgtoolkit.CharacterEntityAdapter{Character: char},
+			nil,
+		)
+
+		// Emit the event
+		err := rpgBus.Publish(context.Background(), attackEvent)
+		require.NoError(t, err)
+
+		// Check that only vicious mockery was removed
+		require.Len(t, char.Resources.ActiveEffects, 1)
+		assert.Equal(t, "Bless", char.Resources.ActiveEffects[0].Name)
+	})
+}

--- a/internal/domain/rulebook/dnd5e/spells/magic_missile.go
+++ b/internal/domain/rulebook/dnd5e/spells/magic_missile.go
@@ -11,7 +11,7 @@ import (
 
 // MagicMissileHandler implements the magic missile spell
 type MagicMissileHandler struct {
-	eventBus   *events.EventBus
+	eventBus   events.Bus
 	diceRoller interface {
 		Roll(numDice, sides, modifier int) (struct{ Total int }, error)
 	}
@@ -22,7 +22,7 @@ type MagicMissileHandler struct {
 }
 
 // NewMagicMissileHandler creates a new magic missile handler
-func NewMagicMissileHandler(eventBus *events.EventBus) *MagicMissileHandler {
+func NewMagicMissileHandler(eventBus events.Bus) *MagicMissileHandler {
 	return &MagicMissileHandler{
 		eventBus: eventBus,
 	}

--- a/internal/domain/rulebook/dnd5e/spells/vicious_mockery.go
+++ b/internal/domain/rulebook/dnd5e/spells/vicious_mockery.go
@@ -184,14 +184,7 @@ func (v *ViciousMockeryHandler) Execute(ctx context.Context, caster *character.C
 		result.Message = "The target shrugs off your mockery!"
 	}
 
-	log.Printf("=== VICIOUS MOCKERY CAST ===")
-	log.Printf("Caster: %s (Level %d)", caster.Name, caster.Level)
-	log.Printf("Target: %s", targetID)
-	log.Printf("Save DC: %d", saveDC)
-	log.Printf("Save Failed: %v", saveFailed)
-	if saveFailed {
-		log.Printf("Damage: %d", result.TotalDamage)
-	}
+	// Vicious mockery cast completed (removed excessive debug logging)
 
 	return result, nil
 }

--- a/internal/repositories/characters/redis.go
+++ b/internal/repositories/characters/redis.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/equipment"
-	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/rulebook/dnd5e"
+	rulebook "github.com/KirkDiggler/dnd-bot-discord/internal/domain/rulebook/dnd5e"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/shared"
 
 	dnderr "github.com/KirkDiggler/dnd-bot-discord/internal/errors"
@@ -272,12 +272,6 @@ func (r *redisRepo) Get(ctx context.Context, id string) (*character.Character, e
 	var data CharacterData
 	if unmarshalErr := json.Unmarshal([]byte(jsonData), &data); unmarshalErr != nil {
 		return nil, fmt.Errorf("failed to unmarshal character: %w", unmarshalErr)
-	}
-
-	// Debug: Log features being loaded
-	log.Printf("DEBUG REDIS: Loading character %s with %d features", data.Name, len(data.Features))
-	for i, feature := range data.Features {
-		log.Printf("DEBUG REDIS: Loaded Feature %d: key=%s, metadata=%v", i, feature.Key, feature.Metadata)
 	}
 
 	// Convert to entity

--- a/internal/repositories/characters/redis.go
+++ b/internal/repositories/characters/redis.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -370,11 +369,7 @@ func (r *redisRepo) Update(ctx context.Context, char *character.Character) error
 	data.CreatedAt = existing.CreatedAt // Preserve creation time
 	data.UpdatedAt = time.Now().UTC()
 
-	// Debug: Log features being saved
-	log.Printf("DEBUG REDIS: Saving character %s with %d features", char.Name, len(data.Features))
-	for i, feature := range data.Features {
-		log.Printf("DEBUG REDIS: Feature %d: key=%s, metadata=%v", i, feature.Key, feature.Metadata)
-	}
+	// Features saved to Redis (removed excessive debug logging)
 
 	// Serialize updated character
 	jsonData, err := json.Marshal(data)

--- a/internal/services/ability/service.go
+++ b/internal/services/ability/service.go
@@ -162,16 +162,8 @@ func (s *service) UseAbility(ctx context.Context, input *UseAbilityInput) (*UseA
 	}
 
 	// Save character state
-	log.Printf("=== SAVING CHARACTER AFTER ABILITY USE ===")
-	log.Printf("Character: %s", char.Name)
-	if char.Resources != nil {
-		log.Printf("Active effects before save: %d", len(char.Resources.ActiveEffects))
-	}
-
 	if updateErr := s.characterService.UpdateEquipment(char); updateErr != nil {
 		log.Printf("Failed to save character state after ability use: %v", updateErr)
-	} else {
-		log.Printf("Character saved successfully")
 	}
 
 	return result, nil

--- a/internal/services/ability/service.go
+++ b/internal/services/ability/service.go
@@ -17,7 +17,7 @@ import (
 type service struct {
 	characterService charService.Service
 	diceRoller       dice.Roller
-	eventBus         *events.EventBus
+	eventBus         events.Bus
 	registry         *HandlerRegistry
 }
 
@@ -25,7 +25,7 @@ type service struct {
 type ServiceConfig struct {
 	CharacterService charService.Service
 	DiceRoller       dice.Roller
-	EventBus         *events.EventBus
+	EventBus         events.Bus
 }
 
 // NewService creates a new ability service without any hardcoded abilities

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -194,7 +194,7 @@ type service struct {
 	characterService charService.Service
 	uuidGenerator    uuid.Generator
 	diceRoller       dice.Roller
-	eventBus         *events.EventBus
+	eventBus         events.Bus
 }
 
 // ServiceConfig holds configuration for the service
@@ -204,7 +204,7 @@ type ServiceConfig struct {
 	CharacterService charService.Service
 	UUIDGenerator    uuid.Generator
 	DiceRoller       dice.Roller
-	EventBus         *events.EventBus
+	EventBus         events.Bus
 }
 
 // NewService creates a new encounter service
@@ -238,10 +238,15 @@ func NewService(cfg *ServiceConfig) Service {
 		svc.diceRoller = dice.NewRandomRoller()
 	}
 
-	// Register spell damage handler if event bus is available
+	// Register event handlers if event bus is available
 	if cfg.EventBus != nil {
+		// Spell damage handler
 		spellDamageHandler := NewSpellDamageHandler(svc)
 		cfg.EventBus.Subscribe(events.OnSpellDamage, spellDamageHandler)
+
+		// Status effect handler
+		statusEffectHandler := NewStatusEffectHandler(svc)
+		cfg.EventBus.Subscribe(events.OnStatusApplied, statusEffectHandler)
 	}
 
 	return svc
@@ -808,6 +813,52 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 
 		// Attack debug logs removed - too verbose during combat
 
+		// Get target character for events
+		var targetChar *character.Character
+		if target.Type == combat.CombatantTypePlayer && target.CharacterID != "" {
+			var getErr error
+			targetChar, getErr = s.characterService.GetByID(target.CharacterID)
+			if getErr != nil {
+				log.Printf("Failed to get target character for events: %v", getErr)
+			}
+		} else {
+			// Create basic character for non-player target
+			targetChar = &character.Character{
+				ID:   target.ID,
+				Name: target.Name,
+			}
+		}
+
+		// Emit BeforeAttackRoll event
+		if s.eventBus != nil {
+			// Get weapon name for the event
+			weaponName := "Unarmed Strike"
+			if char.EquippedSlots[shared.SlotMainHand] != nil {
+				weaponName = char.EquippedSlots[shared.SlotMainHand].GetName()
+			} else if char.EquippedSlots[shared.SlotTwoHanded] != nil {
+				weaponName = char.EquippedSlots[shared.SlotTwoHanded].GetName()
+			}
+
+			beforeAttackEvent := events.NewGameEvent(events.BeforeAttackRoll).
+				WithActor(char).
+				WithTarget(targetChar).
+				WithContext("weapon", weaponName).
+				WithContext("attack_bonus", 0) // Will be calculated by char.Attack()
+
+			if emitErr := s.eventBus.Emit(beforeAttackEvent); emitErr != nil {
+				log.Printf("Failed to emit BeforeAttackRoll event: %v", emitErr)
+			}
+
+			// Check if event was cancelled
+			if beforeAttackEvent.IsCancelled() {
+				result.Hit = false
+				result.Damage = 0
+				result.AttackRoll = 0
+				result.TotalAttack = 0
+				return result, nil
+			}
+		}
+
 		// Use character's attack method
 		attackResults, err := char.Attack()
 		if err != nil {
@@ -869,9 +920,56 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 			result.WeaponName = "Unarmed Strike"
 		}
 
+		// Emit OnAttackRoll event
+		if s.eventBus != nil {
+			onAttackEvent := events.NewGameEvent(events.OnAttackRoll).
+				WithActor(char).
+				WithTarget(targetChar).
+				WithContext("weapon", result.WeaponName).
+				WithContext("attack_roll", result.AttackRoll).
+				WithContext("attack_bonus", result.AttackBonus).
+				WithContext("total_attack", result.TotalAttack).
+				WithContext("target_ac", target.AC)
+
+			if err := s.eventBus.Emit(onAttackEvent); err != nil {
+				log.Printf("Failed to emit OnAttackRoll event: %v", err)
+			}
+
+			// Update attack values from event context if modified
+			if modifiedTotal, ok := onAttackEvent.GetIntContext("total_attack"); ok {
+				result.TotalAttack = modifiedTotal
+			}
+		}
+
 		// Check hit
 		result.Hit = result.TotalAttack >= target.AC
 		result.Critical = result.AttackRoll == 20
+
+		// Emit AfterAttackRoll event
+		if s.eventBus != nil {
+			afterAttackEvent := events.NewGameEvent(events.AfterAttackRoll).
+				WithActor(char).
+				WithTarget(targetChar).
+				WithContext("weapon", result.WeaponName).
+				WithContext("attack_roll", result.AttackRoll).
+				WithContext("attack_bonus", result.AttackBonus).
+				WithContext("total_attack", result.TotalAttack).
+				WithContext("target_ac", target.AC).
+				WithContext("hit", result.Hit).
+				WithContext("critical", result.Critical)
+
+			if err := s.eventBus.Emit(afterAttackEvent); err != nil {
+				log.Printf("Failed to emit AfterAttackRoll event: %v", err)
+			}
+
+			// Update hit/critical from event context if modified
+			if modifiedHit, ok := afterAttackEvent.GetBoolContext("hit"); ok {
+				result.Hit = modifiedHit
+			}
+			if modifiedCrit, ok := afterAttackEvent.GetBoolContext("critical"); ok {
+				result.Critical = modifiedCrit
+			}
+		}
 
 		if result.Hit {
 			result.Damage = attackResult.DamageRoll
@@ -992,10 +1090,151 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 		action := attacker.Actions[input.ActionIndex]
 		result.WeaponName = action.Name
 
-		// Roll attack
-		attackResult, err := s.diceRoller.Roll(1, 20, action.AttackBonus)
-		if err != nil {
-			return nil, dnderr.Wrap(err, "failed to roll attack")
+		// Emit BeforeAttackRoll event
+		if s.eventBus != nil {
+			// Create a basic character representation for the monster
+			monsterChar := &character.Character{
+				ID:   attacker.ID,
+				Name: attacker.Name,
+				Attributes: map[shared.Attribute]*character.AbilityScore{
+					shared.AttributeStrength:     {Score: 10}, // Default if not available
+					shared.AttributeDexterity:    {Score: 10},
+					shared.AttributeConstitution: {Score: 10},
+					shared.AttributeIntelligence: {Score: 10},
+					shared.AttributeWisdom:       {Score: 10},
+					shared.AttributeCharisma:     {Score: 10},
+				},
+			}
+
+			// Use actual monster abilities if available
+			if attacker.Abilities != nil {
+				if str, ok := attacker.Abilities["STR"]; ok {
+					monsterChar.Attributes[shared.AttributeStrength].Score = str
+				}
+				if dex, ok := attacker.Abilities["DEX"]; ok {
+					monsterChar.Attributes[shared.AttributeDexterity].Score = dex
+				}
+				if con, ok := attacker.Abilities["CON"]; ok {
+					monsterChar.Attributes[shared.AttributeConstitution].Score = con
+				}
+				if intl, ok := attacker.Abilities["INT"]; ok {
+					monsterChar.Attributes[shared.AttributeIntelligence].Score = intl
+				}
+				if wis, ok := attacker.Abilities["WIS"]; ok {
+					monsterChar.Attributes[shared.AttributeWisdom].Score = wis
+				}
+				if cha, ok := attacker.Abilities["CHA"]; ok {
+					monsterChar.Attributes[shared.AttributeCharisma].Score = cha
+				}
+			}
+
+			// Get target character
+			var targetChar *character.Character
+			if target.Type == combat.CombatantTypePlayer && target.CharacterID != "" {
+				var err error
+				targetChar, err = s.characterService.GetByID(target.CharacterID)
+				if err != nil {
+					log.Printf("Failed to get target character: %v", err)
+				}
+			} else {
+				// Create basic character for non-player target
+				targetChar = &character.Character{
+					ID:   target.ID,
+					Name: target.Name,
+				}
+			}
+
+			beforeAttackEvent := events.NewGameEvent(events.BeforeAttackRoll).
+				WithActor(monsterChar).
+				WithTarget(targetChar).
+				WithContext("weapon", action.Name).
+				WithContext("attack_bonus", action.AttackBonus)
+
+			if err := s.eventBus.Emit(beforeAttackEvent); err != nil {
+				log.Printf("Failed to emit BeforeAttackRoll event: %v", err)
+			}
+
+			// Check if event was cancelled
+			if beforeAttackEvent.IsCancelled() {
+				result.Hit = false
+				result.Damage = 0
+				result.AttackRoll = 0
+				result.TotalAttack = 0
+				return result, nil
+			}
+
+			// Update attack bonus from event context if modified
+			if modifiedBonus, ok := beforeAttackEvent.GetIntContext("attack_bonus"); ok {
+				action.AttackBonus = modifiedBonus
+			}
+		}
+
+		// Check for disadvantage effects (like Vicious Mockery)
+		hasDisadvantage := false
+		disadvantageEffectIndex := -1
+
+		if attacker.ActiveEffects != nil {
+			for i, effect := range attacker.ActiveEffects {
+				if effect.Name == "Vicious Mockery Disadvantage" {
+					// Check if this effect applies to attack rolls
+					for _, modifier := range effect.Modifiers {
+						if modifier.Type == shared.ModifierTypeDisadvantage {
+							hasDisadvantage = true
+							disadvantageEffectIndex = i
+							break
+						}
+					}
+					if hasDisadvantage {
+						break
+					}
+				}
+			}
+		}
+
+		// Roll attack (with disadvantage if applicable)
+		var attackResult struct {
+			Total int
+			Rolls []int
+		}
+
+		if hasDisadvantage {
+			// Roll twice for disadvantage
+			firstRoll, err := s.diceRoller.Roll(1, 20, action.AttackBonus)
+			if err != nil {
+				return nil, dnderr.Wrap(err, "failed to roll first attack with disadvantage")
+			}
+
+			secondRoll, err := s.diceRoller.Roll(1, 20, action.AttackBonus)
+			if err != nil {
+				return nil, dnderr.Wrap(err, "failed to roll second attack with disadvantage")
+			}
+
+			// Take the lower total
+			if firstRoll.Total <= secondRoll.Total {
+				attackResult.Total = firstRoll.Total
+				attackResult.Rolls = firstRoll.Rolls
+			} else {
+				attackResult.Total = secondRoll.Total
+				attackResult.Rolls = secondRoll.Rolls
+			}
+
+			// Log the disadvantage rolls
+			encounter.AddCombatLogEntry(fmt.Sprintf("%s attacks with disadvantage (Vicious Mockery) - rolled %d and %d, taking %d",
+				attacker.Name, firstRoll.Rolls[0], secondRoll.Rolls[0], attackResult.Rolls[0]))
+
+			// Remove the disadvantage effect after use
+			if disadvantageEffectIndex >= 0 {
+				attacker.ActiveEffects = append(attacker.ActiveEffects[:disadvantageEffectIndex],
+					attacker.ActiveEffects[disadvantageEffectIndex+1:]...)
+			}
+		} else {
+			// Normal attack roll
+			normalResult, err := s.diceRoller.Roll(1, 20, action.AttackBonus)
+			if err != nil {
+				return nil, dnderr.Wrap(err, "failed to roll attack")
+			}
+			attackResult.Total = normalResult.Total
+			attackResult.Rolls = normalResult.Rolls
 		}
 
 		result.AttackRoll = attackResult.Rolls[0]
@@ -1003,9 +1242,154 @@ func (s *service) PerformAttack(ctx context.Context, input *AttackInput) (*Attac
 		result.TotalAttack = attackResult.Total
 		result.DiceRolls = attackResult.Rolls
 
+		// Emit OnAttackRoll event
+		if s.eventBus != nil {
+			monsterChar := &character.Character{
+				ID:   attacker.ID,
+				Name: attacker.Name,
+				Attributes: map[shared.Attribute]*character.AbilityScore{
+					shared.AttributeStrength:     {Score: 10}, // Default if not available
+					shared.AttributeDexterity:    {Score: 10},
+					shared.AttributeConstitution: {Score: 10},
+					shared.AttributeIntelligence: {Score: 10},
+					shared.AttributeWisdom:       {Score: 10},
+					shared.AttributeCharisma:     {Score: 10},
+				},
+			}
+
+			// Use actual monster abilities if available
+			if attacker.Abilities != nil {
+				if str, ok := attacker.Abilities["STR"]; ok {
+					monsterChar.Attributes[shared.AttributeStrength].Score = str
+				}
+				if dex, ok := attacker.Abilities["DEX"]; ok {
+					monsterChar.Attributes[shared.AttributeDexterity].Score = dex
+				}
+				if con, ok := attacker.Abilities["CON"]; ok {
+					monsterChar.Attributes[shared.AttributeConstitution].Score = con
+				}
+				if intl, ok := attacker.Abilities["INT"]; ok {
+					monsterChar.Attributes[shared.AttributeIntelligence].Score = intl
+				}
+				if wis, ok := attacker.Abilities["WIS"]; ok {
+					monsterChar.Attributes[shared.AttributeWisdom].Score = wis
+				}
+				if cha, ok := attacker.Abilities["CHA"]; ok {
+					monsterChar.Attributes[shared.AttributeCharisma].Score = cha
+				}
+			}
+
+			var targetChar *character.Character
+			if target.Type == combat.CombatantTypePlayer && target.CharacterID != "" {
+				var err error
+				targetChar, err = s.characterService.GetByID(target.CharacterID)
+				if err != nil {
+					log.Printf("Failed to get target character: %v", err)
+				}
+			} else {
+				targetChar = &character.Character{
+					ID:   target.ID,
+					Name: target.Name,
+				}
+			}
+
+			onAttackEvent := events.NewGameEvent(events.OnAttackRoll).
+				WithActor(monsterChar).
+				WithTarget(targetChar).
+				WithContext("weapon", action.Name).
+				WithContext("attack_roll", result.AttackRoll).
+				WithContext("attack_bonus", result.AttackBonus).
+				WithContext("total_attack", result.TotalAttack).
+				WithContext("target_ac", target.AC)
+
+			if err := s.eventBus.Emit(onAttackEvent); err != nil {
+				log.Printf("Failed to emit OnAttackRoll event: %v", err)
+			}
+
+			// Update attack values from event context if modified
+			if modifiedTotal, ok := onAttackEvent.GetIntContext("total_attack"); ok {
+				result.TotalAttack = modifiedTotal
+			}
+		}
+
 		// Check hit
 		result.Hit = result.TotalAttack >= target.AC
 		result.Critical = result.AttackRoll == 20
+
+		// Emit AfterAttackRoll event
+		if s.eventBus != nil {
+			monsterChar := &character.Character{
+				ID:   attacker.ID,
+				Name: attacker.Name,
+				Attributes: map[shared.Attribute]*character.AbilityScore{
+					shared.AttributeStrength:     {Score: 10}, // Default if not available
+					shared.AttributeDexterity:    {Score: 10},
+					shared.AttributeConstitution: {Score: 10},
+					shared.AttributeIntelligence: {Score: 10},
+					shared.AttributeWisdom:       {Score: 10},
+					shared.AttributeCharisma:     {Score: 10},
+				},
+			}
+
+			// Use actual monster abilities if available
+			if attacker.Abilities != nil {
+				if str, ok := attacker.Abilities["STR"]; ok {
+					monsterChar.Attributes[shared.AttributeStrength].Score = str
+				}
+				if dex, ok := attacker.Abilities["DEX"]; ok {
+					monsterChar.Attributes[shared.AttributeDexterity].Score = dex
+				}
+				if con, ok := attacker.Abilities["CON"]; ok {
+					monsterChar.Attributes[shared.AttributeConstitution].Score = con
+				}
+				if intl, ok := attacker.Abilities["INT"]; ok {
+					monsterChar.Attributes[shared.AttributeIntelligence].Score = intl
+				}
+				if wis, ok := attacker.Abilities["WIS"]; ok {
+					monsterChar.Attributes[shared.AttributeWisdom].Score = wis
+				}
+				if cha, ok := attacker.Abilities["CHA"]; ok {
+					monsterChar.Attributes[shared.AttributeCharisma].Score = cha
+				}
+			}
+
+			var targetChar *character.Character
+			if target.Type == combat.CombatantTypePlayer && target.CharacterID != "" {
+				var err error
+				targetChar, err = s.characterService.GetByID(target.CharacterID)
+				if err != nil {
+					log.Printf("Failed to get target character: %v", err)
+				}
+			} else {
+				targetChar = &character.Character{
+					ID:   target.ID,
+					Name: target.Name,
+				}
+			}
+
+			afterAttackEvent := events.NewGameEvent(events.AfterAttackRoll).
+				WithActor(monsterChar).
+				WithTarget(targetChar).
+				WithContext("weapon", action.Name).
+				WithContext("attack_roll", result.AttackRoll).
+				WithContext("attack_bonus", result.AttackBonus).
+				WithContext("total_attack", result.TotalAttack).
+				WithContext("target_ac", target.AC).
+				WithContext("hit", result.Hit).
+				WithContext("critical", result.Critical)
+
+			if err := s.eventBus.Emit(afterAttackEvent); err != nil {
+				log.Printf("Failed to emit AfterAttackRoll event: %v", err)
+			}
+
+			// Update hit/critical from event context if modified
+			if modifiedHit, ok := afterAttackEvent.GetBoolContext("hit"); ok {
+				result.Hit = modifiedHit
+			}
+			if modifiedCrit, ok := afterAttackEvent.GetBoolContext("critical"); ok {
+				result.Critical = modifiedCrit
+			}
+		}
 
 		if result.Hit {
 			// Roll damage for each damage component
@@ -1707,4 +2091,112 @@ func (s *service) UpdateMessageID(ctx context.Context, encounterID, messageID, c
 
 	log.Printf("Updated encounter %s with message ID %s in channel %s", encounterID, messageID, channelID)
 	return nil
+}
+
+// StatusEffectHandler handles status effect events for encounters
+type StatusEffectHandler struct {
+	service Service
+}
+
+// NewStatusEffectHandler creates a new status effect handler
+func NewStatusEffectHandler(service Service) *StatusEffectHandler {
+	return &StatusEffectHandler{
+		service: service,
+	}
+}
+
+// HandleEvent processes status applied events
+func (h *StatusEffectHandler) HandleEvent(event *events.GameEvent) error {
+	// Only handle status applied events
+	if event.Type != events.OnStatusApplied {
+		return nil
+	}
+
+	// Get target ID
+	targetID, exists := event.GetStringContext(events.ContextTargetID)
+	if !exists || targetID == "" {
+		log.Printf("StatusEffectHandler: No target ID for status effect")
+		return nil
+	}
+
+	// Get effect details
+	effectName, _ := event.GetStringContext("effect_name")
+	effectType, _ := event.GetStringContext("effect_type")
+	duration, _ := event.GetIntContext("effect_duration")
+
+	// Check if this is vicious mockery disadvantage
+	if effectType == "disadvantage_next_attack" && effectName == "Vicious Mockery Disadvantage" {
+		// Apply to both players and monsters
+		log.Printf("StatusEffectHandler: Applying vicious mockery disadvantage to target %s", targetID)
+
+		// First check if target is a player character
+		if event.Actor != nil && event.Actor.OwnerID != "" {
+			// For players, the effect is handled through character.Resources.ActiveEffects
+			// This is already done in the vicious_mockery.go ApplyViciousMockeryDisadvantage function
+			log.Printf("StatusEffectHandler: Target is a player, effect already applied to character")
+			return nil
+		}
+
+		// For monsters, we need to find them in an active encounter
+		// Get encounter ID from context if available
+		encounterID, exists := event.GetStringContext(events.ContextEncounterID)
+		if !exists || encounterID == "" {
+			// Try to find an active encounter containing this target
+			// This would require additional context or a repository method to search
+			log.Printf("StatusEffectHandler: No encounter ID, cannot apply effect to monster")
+			return nil
+		}
+
+		// Get the encounter
+		ctx := context.Background()
+		encounter, err := h.service.GetEncounter(ctx, encounterID)
+		if err != nil {
+			log.Printf("StatusEffectHandler: Failed to get encounter: %v", err)
+			return nil
+		}
+
+		// Find the target combatant
+		combatant, exists := encounter.Combatants[targetID]
+		if !exists {
+			log.Printf("StatusEffectHandler: Target %s not found in encounter", targetID)
+			return nil
+		}
+
+		// Create the effect
+		effect := &shared.ActiveEffect{
+			ID:           uuid.NewGoogleUUIDGenerator().New(),
+			Name:         effectName,
+			Description:  "Disadvantage on next attack roll",
+			Source:       "Vicious Mockery",
+			Duration:     duration,
+			DurationType: shared.DurationTypeRounds,
+			Modifiers: []shared.Modifier{
+				{
+					Type: shared.ModifierTypeDisadvantage,
+				},
+			},
+		}
+
+		// Initialize ActiveEffects if nil
+		if combatant.ActiveEffects == nil {
+			combatant.ActiveEffects = []*shared.ActiveEffect{}
+		}
+
+		// Add the effect to the combatant
+		combatant.ActiveEffects = append(combatant.ActiveEffects, effect)
+
+		// Update the encounter - we can't access repository directly from Service interface
+		// So we'll rely on the encounter being saved elsewhere in the flow
+		log.Printf("StatusEffectHandler: Effect applied, encounter will be saved by calling method")
+
+		log.Printf("StatusEffectHandler: Successfully applied vicious mockery disadvantage to %s (%s)",
+			combatant.Name, combatant.Type)
+	}
+
+	return nil
+}
+
+// Priority returns the handler priority
+func (h *StatusEffectHandler) Priority() int {
+	return 100
 }

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -443,7 +443,6 @@ func (s *service) AddPlayer(ctx context.Context, encounterID, playerID, characte
 	}
 
 	// Reset action economy for the start of combat
-	log.Printf("[ACTION ECONOMY] Resetting actions for %s as they join combat", char.Name)
 	char.StartNewTurn()
 
 	// Save character to persist the reset action economy
@@ -728,7 +727,6 @@ func (s *service) NextTurn(ctx context.Context, encounterID, userID string) erro
 			}
 
 			// Reset per-turn abilities
-			log.Printf("[ACTION ECONOMY] New round started - resetting actions for %s", char.Name)
 			char.StartNewTurn()
 
 			// Save character to persist the reset

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -1825,8 +1825,6 @@ func (s *service) ProcessMonsterTurn(ctx context.Context, encounterID, monsterID
 	// Find a target (first active player)
 	var target *combat.Combatant
 	for _, combatant := range encounter.Combatants {
-		log.Printf("ProcessMonsterTurn - Checking combatant %s: Type=%s, IsActive=%v, HP=%d/%d",
-			combatant.Name, combatant.Type, combatant.IsActive, combatant.CurrentHP, combatant.MaxHP)
 		if combatant.Type == combat.CombatantTypePlayer && combatant.IsActive {
 			target = combatant
 			break

--- a/internal/services/encounter/service.go
+++ b/internal/services/encounter/service.go
@@ -2061,7 +2061,7 @@ func (h *StatusEffectHandler) HandleEvent(event *events.GameEvent) error {
 		log.Printf("StatusEffectHandler: Applying vicious mockery disadvantage to target %s", targetID)
 
 		// First check if target is a player character
-		if event.Actor != nil && event.Actor.OwnerID != "" {
+		if event.Target != nil && event.Target.OwnerID != "" {
 			// For players, the effect is handled through character.Resources.ActiveEffects
 			// This is already done in the vicious_mockery.go ApplyViciousMockeryDisadvantage function
 			log.Printf("StatusEffectHandler: Target is a player, effect already applied to character")

--- a/internal/services/encounter/spell_damage_handler.go
+++ b/internal/services/encounter/spell_damage_handler.go
@@ -39,15 +39,13 @@ func (h *SpellDamageHandler) HandleEvent(event *events.GameEvent) error {
 	}
 
 	if targetID == "" {
-		log.Printf("SpellDamageHandler: No target ID for spell damage")
-		return nil
+		return nil // No target ID for spell damage
 	}
 
 	// Get encounter ID (would need to be added to event context)
 	encounterID, exists := event.GetStringContext(events.ContextEncounterID)
 	if !exists {
-		log.Printf("SpellDamageHandler: No encounter ID in spell damage event")
-		return nil
+		return nil // No encounter ID in spell damage event
 	}
 
 	// Apply the damage
@@ -64,12 +62,7 @@ func (h *SpellDamageHandler) HandleEvent(event *events.GameEvent) error {
 		return err
 	}
 
-	// Get spell name for logging
-	spellName, _ := event.GetStringContext(events.ContextSpellName)
-	damageType, _ := event.GetStringContext(events.ContextDamageType)
-
-	log.Printf("SpellDamageHandler: Applied %d %s damage from %s to target %s",
-		damage, damageType, spellName, targetID)
+	// Spell damage applied successfully (removed excessive logging)
 
 	return nil
 }

--- a/internal/services/provider.go
+++ b/internal/services/provider.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"github.com/KirkDiggler/dnd-bot-discord/internal/adapters/rpgtoolkit"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/clients/dnd5e"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/dice"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/events"
@@ -17,6 +18,7 @@ import (
 	lootService "github.com/KirkDiggler/dnd-bot-discord/internal/services/loot"
 	monsterService "github.com/KirkDiggler/dnd-bot-discord/internal/services/monster"
 	sessionService "github.com/KirkDiggler/dnd-bot-discord/internal/services/session"
+	rpgevents "github.com/KirkDiggler/rpg-toolkit/events"
 )
 
 // Provider holds all service instances
@@ -30,6 +32,8 @@ type Provider struct {
 	AbilityService   abilityService.Service
 	DiceRoller       dice.Roller
 	EventBus         *events.EventBus
+	EventBusAdapter  *rpgtoolkit.EventBusAdapter
+	RPGEventBus      *rpgevents.Bus
 }
 
 // ProviderConfig holds configuration for creating services
@@ -44,8 +48,11 @@ type ProviderConfig struct {
 
 // NewProvider creates a new service provider with all services initialized
 func NewProvider(cfg *ProviderConfig) *Provider {
-	// Create event bus
+	// Create rpg-toolkit event bus adapter
+	eventBusAdapter := rpgtoolkit.NewEventBusAdapter()
+	// We need both for now during migration
 	eventBus := events.NewEventBus()
+	rpgBus := eventBusAdapter.GetRPGBus()
 
 	// Use in-memory repository if none provided
 	charRepo := cfg.CharacterRepository
@@ -122,6 +129,7 @@ func NewProvider(cfg *ProviderConfig) *Provider {
 	// Register D&D 5e abilities
 	abilities.RegisterAll(abilService, &abilities.RegistryConfig{
 		EventBus:         eventBus,
+		RPGEventBus:      rpgBus,
 		DiceRoller:       cfg.DiceRoller,
 		EncounterService: encService,
 		CharacterService: charService,
@@ -137,5 +145,7 @@ func NewProvider(cfg *ProviderConfig) *Provider {
 		AbilityService:   abilService,
 		DiceRoller:       cfg.DiceRoller,
 		EventBus:         eventBus,
+		EventBusAdapter:  eventBusAdapter,
+		RPGEventBus:      rpgBus,
 	}
 }

--- a/internal/services/provider.go
+++ b/internal/services/provider.go
@@ -31,8 +31,7 @@ type Provider struct {
 	LootService      lootService.Service
 	AbilityService   abilityService.Service
 	DiceRoller       dice.Roller
-	EventBus         *events.EventBus
-	EventBusAdapter  *rpgtoolkit.EventBusAdapter
+	EventBus         events.Bus // Now using the interface
 	RPGEventBus      *rpgevents.Bus
 }
 
@@ -48,10 +47,10 @@ type ProviderConfig struct {
 
 // NewProvider creates a new service provider with all services initialized
 func NewProvider(cfg *ProviderConfig) *Provider {
-	// Create rpg-toolkit event bus adapter
+	// Create rpg-toolkit event bus adapter that replaces the old event bus
 	eventBusAdapter := rpgtoolkit.NewEventBusAdapter()
-	// We need both for now during migration
-	eventBus := events.NewEventBus()
+	// The adapter now IS our event bus
+	eventBus := eventBusAdapter
 	rpgBus := eventBusAdapter.GetRPGBus()
 
 	// Use in-memory repository if none provided
@@ -145,7 +144,6 @@ func NewProvider(cfg *ProviderConfig) *Provider {
 		AbilityService:   abilService,
 		DiceRoller:       cfg.DiceRoller,
 		EventBus:         eventBus,
-		EventBusAdapter:  eventBusAdapter,
 		RPGEventBus:      rpgBus,
 	}
 }


### PR DESCRIPTION
## Summary
Integrates rpg-toolkit event system to replace Discord bot's event system, with full MonsterEntityAdapter support and working vicious mockery disadvantage for both players and monsters.

## What's Implemented

### ✅ rpg-toolkit Event Bus Integration
- Created EventBusAdapter that implements Discord bot's Bus interface using rpg-toolkit
- Bidirectional event conversion between Discord bot and rpg-toolkit formats
- All existing Discord bot functionality preserved while gaining rpg-toolkit capabilities

### ✅ MonsterEntityAdapter for rpg-toolkit Entities
- Wraps combat.Combatant as rpg-toolkit Entity for event system participation
- Monsters can now be sources/targets in rpg-toolkit events
- Enables monsters to receive effects like vicious mockery disadvantage

### ✅ Fixed Vicious Mockery Disadvantage System
- **Root Cause**: EventBusAdapter was losing context data during event conversion
- **Solution**: Enhanced convertToGameEvent to copy all known context fields
- **Result**: Monsters now properly receive disadvantage on next attack after vicious mockery

### ✅ Excessive Logging Cleanup
- Removed verbose debug logs from ability service, spell handlers, encounter service
- Kept essential error logging for troubleshooting
- Much cleaner log output during gameplay

## Test Results
- ✅ All existing tests pass
- ✅ Vicious mockery disadvantage confirmed working in live gameplay
- ✅ MonsterEntityAdapter integration tests pass
- ✅ Event bus adapter handles bidirectional conversion correctly

## Evidence of Success
```
StatusEffectHandler: Applying vicious mockery disadvantage to target c2d90888...
Rolling 1 d 20 : [9] total: 9    # First roll (disadvantage)
Rolling 1 d 20 : [11] total: 11  # Second roll (disadvantage)
```

Monster attacks now show two d20 rolls when affected by vicious mockery, proving disadvantage is working\!

## Next Steps
This PR establishes the foundation for complete rpg-toolkit migration:

### rpg-toolkit Enhancements Needed
- **Proficiency System** (rpg-toolkit#29): Weapon/skill/save proficiencies
- **Resource Management** (rpg-toolkit#30): Spell slots and ability uses
- **Equipment System** (rpg-toolkit#31): Weapons with properties and AC
- **Enhanced Conditions** (rpg-toolkit#32): D&D 5e condition mechanics
- **Feature System** (rpg-toolkit#33): Class/race abilities with events

### Discord Bot Migration
- **Remove EventBusAdapter** (#258): Complete migration to pure rpg-toolkit events
- **Local D&D 5e Rulebook**: Use rpg-toolkit as authoritative rules engine

## Breaking Changes
None - all existing functionality preserved.

## Files Changed
- `internal/adapters/rpgtoolkit/` - EventBusAdapter and entity adapters
- `internal/services/provider.go` - Uses EventBusAdapter as event bus
- `internal/domain/rulebook/dnd5e/abilities/vicious_mockery_rpg.go` - rpg-toolkit listener
- Various logging cleanup throughout system

🤖 Generated with [Claude Code](https://claude.ai/code)