### PR TITLE
fix: Shorten fighting style descriptions for Discord 100 char limit

### DIFF
--- a/docs/architecture/class-feature-selection-refactor.md
+++ b/docs/architecture/class-feature-selection-refactor.md
@@ -1,0 +1,166 @@
+# Class Feature Selection Architecture Refactor
+
+## Current Problems
+1. Feature options (fighting styles, domains, etc.) are hardcoded in Discord handlers
+2. No connection to D&D 5e API data
+3. Cleric Divine Domain selection is completely missing
+4. Violates separation of concerns - game logic in UI layer
+
+## Proposed Architecture
+
+### Data Flow
+```
+D&D 5e API → Domain Models → Character Service → Discord Handler
+(source)      (structure)     (business logic)   (rendering only)
+```
+
+### Layer Responsibilities
+
+#### 1. D&D 5e API Client
+- Fetch class level data including feature choices
+- Example: `/api/classes/fighter/levels/1` returns fighting style options
+
+#### 2. Rulebook Domain (`/internal/domain/rulebook/dnd5e`)
+All D&D 5e specific types belong here:
+
+```go
+// class.go - Extend existing Class struct
+type Class struct {
+    // ... existing fields ...
+    LevelFeatures map[int][]*ClassLevelFeature `json:"level_features"`
+}
+
+// class_features.go - New file for feature-specific types
+type ClassLevelFeature struct {
+    Level       int                `json:"level"`
+    Feature     *CharacterFeature  `json:"feature"`
+    Choices     []*FeatureChoice   `json:"choices"`
+}
+
+type FeatureChoice struct {
+    Type        string             `json:"type"` // "fighting_style", "divine_domain", etc.
+    Choose      int                `json:"choose"`
+    Options     []*FeatureOption   `json:"options"`
+}
+
+type FeatureOption struct {
+    Key         string             `json:"key"`
+    Name        string             `json:"name"`
+    Description string             `json:"description"`
+    // For domains, could include domain spells
+    Metadata    map[string]any     `json:"metadata"`
+}
+
+// fighting_styles.go - Fighting style definitions
+type FightingStyle struct {
+    Key         string `json:"key"`
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Classes     []string `json:"classes"` // ["fighter", "ranger", "paladin"]
+}
+
+// divine_domains.go - Divine domain definitions  
+type DivineDomain struct {
+    Key          string   `json:"key"`
+    Name         string   `json:"name"`
+    Description  string   `json:"description"`
+    DomainSpells []string `json:"domain_spells"` // Spell keys by level
+}
+```
+
+**Key Principle**: The rulebook is the single source of truth for all D&D 5e game mechanics
+
+#### 3. Character Service
+- Query domain for required feature selections
+- Validate selections
+- Store selections in character features with metadata
+
+#### 4. Discord Handler
+- Only responsible for rendering
+- Gets options from service/domain
+- Presents them in Discord UI format
+- No hardcoded game data
+
+## Implementation Progress
+
+### ✅ Completed
+1. **Domain Models** - Created proper types in rulebook domain:
+   - `feature_choices.go` - Core types for feature selection system
+   - `fighting_styles.go` - All fighting styles with class restrictions
+   - `divine_domains.go` - All PHB divine domains with domain spells
+   - `ranger_features.go` - Favored enemy and natural explorer choices
+   - `class_feature_registry.go` - Registry to get choices by class/level
+
+### 🚧 Next Steps
+1. **Update Character Service**
+   - Use `GetPendingFeatureChoices` to check what needs selection
+   - Store selections in character feature metadata
+   
+2. **Refactor Discord Handler**
+   - Remove hardcoded options
+   - Use rulebook domain for all feature data
+   - Handler only formats for Discord UI
+
+3. **Testing**
+   - Integration test for Fighter fighting style
+   - Verify Cleric divine domain works
+   - Test all existing classes still function
+
+## Implementation Plan
+
+### Phase 1: Fighter (Proof of Concept)
+1. **API Client Enhancement**
+   - Add method to fetch class level features
+   - Parse fighting style options from API
+
+2. **Domain Model Updates**
+   - Extend Class struct with level features
+   - Create FeatureChoice models
+
+3. **Service Layer**
+   - Add method to get pending feature choices
+   - Validate and store selections
+
+4. **Handler Refactor**
+   - Remove hardcoded fighting styles
+   - Use domain data for options
+
+5. **Testing**
+   - Integration test full flow
+   - Verify Fighter creation works end-to-end
+
+### Phase 2: Apply Pattern
+Once Fighter works:
+1. **Ranger** - Two selections (favored enemy, natural explorer)
+2. **Cleric** - Divine Domain (includes domain spells)
+3. **Future** - Sorcerer origin, Warlock patron (when implemented)
+
+### Phase 3: Advanced Features
+- Domain spells automatically granted
+- Feature prerequisites/restrictions
+- Multi-level features (e.g., Wizard school at 2)
+
+## Benefits
+1. **Maintainability** - Changes to D&D rules only require API updates
+2. **Extensibility** - Easy to add new classes/features
+3. **Correctness** - Single source of truth (API)
+4. **Testing** - Each layer can be tested independently
+
+## Risks & Mitigation
+1. **API Availability** - Cache responses, have fallback data
+2. **Breaking Changes** - Version API calls
+3. **Performance** - Cache class data after first fetch
+4. **Complexity** - Start simple with Fighter, iterate
+
+## Success Criteria
+1. Fighter can select fighting style from API data
+2. Selection stored properly in character
+3. No hardcoded options in handler
+4. All existing tests pass
+5. Can extend pattern to other classes
+
+## Next Steps
+1. Create GitHub issue for tracking
+2. Implement Fighter vertical slice
+3. Get PR reviewed and merged
+4. Apply to remaining classes

--- a/docs/class-feature-selection-status.md
+++ b/docs/class-feature-selection-status.md
@@ -1,0 +1,51 @@
+# Class Feature Selection Status
+
+## Overview
+Tracking which classes need feature selections during character creation at level 1.
+
+## Classes That Need Selections at Level 1
+
+### ✅ Implemented
+1. **Fighter** - Fighting Style ✅
+   - Archery, Defense, Dueling, Great Weapon Fighting, Protection, Two-Weapon Fighting
+   
+2. **Ranger** - Two selections ✅
+   - Favored Enemy (aberrations, beasts, celestials, etc.)
+   - Natural Explorer (arctic, coast, desert, etc.)
+
+### ❌ Not Implemented
+1. **Cleric** - Divine Domain ❌
+   - PHB Domains: Knowledge, Life, Light, Nature, Tempest, Trickery, War
+   - Currently shows as TODO in code
+   - This is why users see "class features" but get no selection
+
+## Classes With No Level 1 Selections
+These classes should work fine as-is:
+1. **Barbarian** - No selections (Path at level 3)
+2. **Bard** - No selections (College at level 3)  
+3. **Monk** - No selections (Tradition at level 3)
+4. **Paladin** - No selections (Oath at level 3)
+5. **Rogue** - No selections (Archetype at level 3)
+
+## Partially Implemented Classes (Not in Phase 1 yet)
+1. **Druid** - Circle selection at level 2
+2. **Sorcerer** - Sorcerous Origin at level 1 (needs implementation when class is added)
+3. **Warlock** - Otherworldly Patron at level 1 (needs implementation when class is added)
+4. **Wizard** - Arcane Tradition at level 2
+
+## Implementation Status
+
+### Current Issues
+1. **Cleric Divine Domain** - Not implemented, causing confusion during character creation
+2. Handler only checks for `favored_enemy` and `fighting_style` in main handler
+3. No `ShowDivineDomainSelection` method exists
+
+### Code Locations
+- Feature selection handler: `/internal/handlers/discord/dnd/character/class_features.go`
+- Main handler checks: `/internal/handlers/discord/handler.go`
+- Feature definitions: `/internal/domain/rulebook/dnd5e/features/features.go`
+
+## Next Steps
+1. Implement Divine Domain selection for Cleric
+2. Test all implemented classes (Fighter, Ranger, Barbarian, Bard, Monk, Paladin, Rogue, Cleric)
+3. Consider if domain spells should be automatically added

--- a/internal/domain/rulebook/dnd5e/class_feature_registry.go
+++ b/internal/domain/rulebook/dnd5e/class_feature_registry.go
@@ -1,0 +1,80 @@
+package rulebook
+
+// GetClassFeatureChoices returns all feature choices required for a class at a given level
+func GetClassFeatureChoices(className string, level int) []*FeatureChoice {
+	var choices []*FeatureChoice
+
+	// Only return choices for features gained up to the specified level
+	switch className {
+	case "cleric":
+		if level >= 1 {
+			choices = append(choices, GetDivineDomainChoice())
+		}
+	case "fighter":
+		if level >= 1 {
+			choices = append(choices, GetFightingStyleChoice(className))
+		}
+	case "ranger":
+		if level >= 1 {
+			choices = append(choices, GetFavoredEnemyChoice(), GetNaturalExplorerChoice())
+		}
+	case "paladin":
+		if level >= 2 {
+			choices = append(choices, GetFightingStyleChoice(className))
+		}
+	// Other classes don't have choices at early levels
+	case "barbarian", "bard", "monk", "rogue":
+		// No choices at level 1
+	// Not yet implemented classes
+	case "druid", "sorcerer", "warlock", "wizard":
+		// TODO: Add when these classes are fully implemented
+	}
+
+	return choices
+}
+
+// GetPendingFeatureChoices returns feature choices that haven't been made yet
+func GetPendingFeatureChoices(char *CharacterFeature, className string, level int) []*FeatureChoice {
+	allChoices := GetClassFeatureChoices(className, level)
+	var pendingChoices []*FeatureChoice
+
+	// Check which choices have already been made
+	for _, choice := range allChoices {
+		// Check if this choice has been made by looking at feature metadata
+		choiceMade := false
+		if char != nil && char.Key == choice.FeatureKey {
+			if char.Metadata != nil {
+				// Different features store their selections differently
+				switch choice.Type {
+				case FeatureChoiceTypeFightingStyle:
+					_, choiceMade = char.Metadata["style"]
+				case FeatureChoiceTypeDivineDomain:
+					_, choiceMade = char.Metadata["domain"]
+				case FeatureChoiceTypeFavoredEnemy:
+					_, choiceMade = char.Metadata["enemy_type"]
+				case FeatureChoiceTypeNaturalExplorer:
+					_, choiceMade = char.Metadata["terrain_type"]
+				}
+			}
+		}
+
+		if !choiceMade {
+			pendingChoices = append(pendingChoices, choice)
+		}
+	}
+
+	return pendingChoices
+}
+
+// GetFeatureChoiceByType returns a specific feature choice for a class
+func GetFeatureChoiceByType(className string, choiceType FeatureChoiceType) *FeatureChoice {
+	choices := GetClassFeatureChoices(className, 20) // Get all choices up to level 20
+
+	for _, choice := range choices {
+		if choice.Type == choiceType {
+			return choice
+		}
+	}
+
+	return nil
+}

--- a/internal/domain/rulebook/dnd5e/divine_domains.go
+++ b/internal/domain/rulebook/dnd5e/divine_domains.go
@@ -1,0 +1,133 @@
+package rulebook
+
+// DivineDomain represents a cleric's divine domain
+type DivineDomain struct {
+	Key          string           `json:"key"`
+	Name         string           `json:"name"`
+	Description  string           `json:"description"`
+	DomainSpells map[int][]string `json:"domain_spells"` // Spell keys by spell level
+	Features     []DomainFeature  `json:"features"`      // Additional features granted
+}
+
+// DomainFeature represents a feature granted by a divine domain
+type DomainFeature struct {
+	Level       int    `json:"level"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// GetDivineDomains returns all PHB divine domains
+func GetDivineDomains() []DivineDomain {
+	return []DivineDomain{
+		{
+			Key:         "knowledge",
+			Name:        "Knowledge Domain",
+			Description: "The gods of knowledge value learning and understanding above all. You gain proficiency in two skills and languages.",
+			DomainSpells: map[int][]string{
+				1: {"command", "identify"},
+				3: {"augury", "suggestion"},
+				5: {"nondetection", "speak-with-dead"},
+				7: {"arcane-eye", "confusion"},
+				9: {"legend-lore", "scrying"},
+			},
+		},
+		{
+			Key:         "life",
+			Name:        "Life Domain",
+			Description: "The Life domain focuses on the vibrant positive energy that sustains all life. You gain heavy armor proficiency and improved healing.",
+			DomainSpells: map[int][]string{
+				1: {"bless", "cure-wounds"},
+				3: {"lesser-restoration", "spiritual-weapon"},
+				5: {"beacon-of-hope", "revivify"},
+				7: {"death-ward", "guardian-of-faith"},
+				9: {"mass-cure-wounds", "raise-dead"},
+			},
+		},
+		{
+			Key:         "light",
+			Name:        "Light Domain",
+			Description: "Gods of light promote the ideals of rebirth, renewal, truth, vigilance, and beauty. You gain the light cantrip and defensive abilities.",
+			DomainSpells: map[int][]string{
+				1: {"burning-hands", "faerie-fire"},
+				3: {"flaming-sphere", "scorching-ray"},
+				5: {"daylight", "fireball"},
+				7: {"guardian-of-faith", "wall-of-fire"},
+				9: {"flame-strike", "scrying"},
+			},
+		},
+		{
+			Key:         "nature",
+			Name:        "Nature Domain",
+			Description: "Gods of nature are as varied as the natural world itself. You gain a druid cantrip and proficiency with heavy armor.",
+			DomainSpells: map[int][]string{
+				1: {"animal-friendship", "speak-with-animals"},
+				3: {"barkskin", "spike-growth"},
+				5: {"plant-growth", "wind-wall"},
+				7: {"dominate-beast", "grasping-vine"},
+				9: {"insect-plague", "tree-stride"},
+			},
+		},
+		{
+			Key:         "tempest",
+			Name:        "Tempest Domain",
+			Description: "Gods of the tempest govern storms, sea, and sky. You gain proficiency with martial weapons and heavy armor.",
+			DomainSpells: map[int][]string{
+				1: {"fog-cloud", "thunderwave"},
+				3: {"gust-of-wind", "shatter"},
+				5: {"call-lightning", "sleet-storm"},
+				7: {"control-water", "ice-storm"},
+				9: {"destructive-wave", "insect-plague"},
+			},
+		},
+		{
+			Key:         "trickery",
+			Name:        "Trickery Domain",
+			Description: "Gods of trickery are mischief-makers and instigators. You can use your Channel Divinity to create an illusory duplicate.",
+			DomainSpells: map[int][]string{
+				1: {"charm-person", "disguise-self"},
+				3: {"mirror-image", "pass-without-trace"},
+				5: {"blink", "dispel-magic"},
+				7: {"dimension-door", "polymorph"},
+				9: {"dominate-person", "modify-memory"},
+			},
+		},
+		{
+			Key:         "war",
+			Name:        "War Domain",
+			Description: "Gods of war watch over warriors and reward acts of violence. You gain proficiency with martial weapons and heavy armor.",
+			DomainSpells: map[int][]string{
+				1: {"divine-favor", "shield-of-faith"},
+				3: {"magic-weapon", "spiritual-weapon"},
+				5: {"crusaders-mantle", "spirit-guardians"},
+				7: {"freedom-of-movement", "stoneskin"},
+				9: {"flame-strike", "hold-monster"},
+			},
+		},
+	}
+}
+
+// GetDivineDomainChoice returns a FeatureChoice for divine domain selection
+func GetDivineDomainChoice() *FeatureChoice {
+	domains := GetDivineDomains()
+	options := make([]FeatureOption, len(domains))
+
+	for i, domain := range domains {
+		options[i] = FeatureOption{
+			Key:         domain.Key,
+			Name:        domain.Name,
+			Description: domain.Description,
+			Metadata: map[string]any{
+				"domain_spells": domain.DomainSpells,
+			},
+		}
+	}
+
+	return &FeatureChoice{
+		Type:        FeatureChoiceTypeDivineDomain,
+		FeatureKey:  "divine_domain",
+		Name:        "Divine Domain",
+		Description: "Choose one domain related to your deity. Your choice grants you domain spells and other features.",
+		Choose:      1,
+		Options:     options,
+	}
+}

--- a/internal/domain/rulebook/dnd5e/feature_choices.go
+++ b/internal/domain/rulebook/dnd5e/feature_choices.go
@@ -1,0 +1,45 @@
+package rulebook
+
+// FeatureChoiceType represents the type of choice
+type FeatureChoiceType string
+
+const (
+	FeatureChoiceTypeFightingStyle   FeatureChoiceType = "fighting_style"
+	FeatureChoiceTypeDivineDomain    FeatureChoiceType = "divine_domain"
+	FeatureChoiceTypeFavoredEnemy    FeatureChoiceType = "favored_enemy"
+	FeatureChoiceTypeNaturalExplorer FeatureChoiceType = "natural_explorer"
+	// Future additions:
+	// FeatureChoiceTypeSorcerousOrigin FeatureChoiceType = "sorcerous_origin"
+	// FeatureChoiceTypeOtherworldlyPatron FeatureChoiceType = "otherworldly_patron"
+)
+
+// FeatureChoice represents a choice that must be made for a feature
+type FeatureChoice struct {
+	Type        FeatureChoiceType `json:"type"`
+	FeatureKey  string            `json:"feature_key"` // Links to CharacterFeature.Key
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Choose      int               `json:"choose"` // How many to choose
+	Options     []FeatureOption   `json:"options"`
+}
+
+// FeatureOption represents one option in a feature choice
+type FeatureOption struct {
+	Key         string         `json:"key"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+}
+
+// ClassFeatures represents all features and choices for a class at each level
+type ClassFeatures struct {
+	ClassName string                      `json:"class_name"`
+	Features  map[int][]ClassLevelFeature `json:"features"` // Keyed by level
+}
+
+// ClassLevelFeature represents a feature gained at a specific level
+type ClassLevelFeature struct {
+	Level   int               `json:"level"`
+	Feature *CharacterFeature `json:"feature"`
+	Choice  *FeatureChoice    `json:"choice,omitempty"` // Optional choice required
+}

--- a/internal/domain/rulebook/dnd5e/fighting_styles.go
+++ b/internal/domain/rulebook/dnd5e/fighting_styles.go
@@ -1,0 +1,94 @@
+package rulebook
+
+// FightingStyle represents a combat style that can be chosen by certain classes
+type FightingStyle struct {
+	Key         string   `json:"key"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Classes     []string `json:"classes"` // Classes that can choose this style
+}
+
+// GetFightingStyles returns all available fighting styles
+func GetFightingStyles() []FightingStyle {
+	return []FightingStyle{
+		{
+			Key:         "archery",
+			Name:        "Archery",
+			Description: "You gain a +2 bonus to attack rolls you make with ranged weapons.",
+			Classes:     []string{"fighter", "ranger"},
+		},
+		{
+			Key:         "defense",
+			Name:        "Defense",
+			Description: "While you are wearing armor, you gain a +1 bonus to AC.",
+			Classes:     []string{"fighter", "ranger", "paladin"},
+		},
+		{
+			Key:         "dueling",
+			Name:        "Dueling",
+			Description: "When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon.",
+			Classes:     []string{"fighter", "ranger", "paladin"},
+		},
+		{
+			Key:         "great_weapon_fighting",
+			Name:        "Great Weapon Fighting",
+			Description: "When you roll a 1 or 2 on a damage die for an attack you make with a melee weapon that you are wielding with two hands, you can reroll the die and must use the new roll. The weapon must have the two-handed or versatile property.",
+			Classes:     []string{"fighter", "paladin"},
+		},
+		{
+			Key:         "protection",
+			Name:        "Protection",
+			Description: "When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll. You must be wielding a shield.",
+			Classes:     []string{"fighter", "paladin"},
+		},
+		{
+			Key:         "two_weapon_fighting",
+			Name:        "Two-Weapon Fighting",
+			Description: "When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack.",
+			Classes:     []string{"fighter", "ranger"},
+		},
+	}
+}
+
+// GetFightingStylesForClass returns fighting styles available to a specific class
+func GetFightingStylesForClass(className string) []FightingStyle {
+	allStyles := GetFightingStyles()
+	var classStyles []FightingStyle
+
+	for _, style := range allStyles {
+		for _, class := range style.Classes {
+			if class == className {
+				classStyles = append(classStyles, style)
+				break
+			}
+		}
+	}
+
+	return classStyles
+}
+
+// GetFightingStyleChoice returns a FeatureChoice for fighting style selection
+func GetFightingStyleChoice(className string) *FeatureChoice {
+	styles := GetFightingStylesForClass(className)
+	if len(styles) == 0 {
+		return nil
+	}
+
+	options := make([]FeatureOption, len(styles))
+	for i, style := range styles {
+		options[i] = FeatureOption{
+			Key:         style.Key,
+			Name:        style.Name,
+			Description: style.Description,
+		}
+	}
+
+	return &FeatureChoice{
+		Type:        FeatureChoiceTypeFightingStyle,
+		FeatureKey:  "fighting_style",
+		Name:        "Fighting Style",
+		Description: "You adopt a particular style of fighting as your specialty.",
+		Choose:      1,
+		Options:     options,
+	}
+}

--- a/internal/domain/rulebook/dnd5e/fighting_styles.go
+++ b/internal/domain/rulebook/dnd5e/fighting_styles.go
@@ -26,25 +26,25 @@ func GetFightingStyles() []FightingStyle {
 		{
 			Key:         "dueling",
 			Name:        "Dueling",
-			Description: "When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon.",
+			Description: "+2 damage when wielding a melee weapon in one hand with no other weapons.",
 			Classes:     []string{"fighter", "ranger", "paladin"},
 		},
 		{
 			Key:         "great_weapon_fighting",
 			Name:        "Great Weapon Fighting",
-			Description: "When you roll a 1 or 2 on a damage die for an attack you make with a melee weapon that you are wielding with two hands, you can reroll the die and must use the new roll. The weapon must have the two-handed or versatile property.",
+			Description: "Reroll 1-2 on damage dice with two-handed or versatile weapons.",
 			Classes:     []string{"fighter", "paladin"},
 		},
 		{
 			Key:         "protection",
 			Name:        "Protection",
-			Description: "When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll. You must be wielding a shield.",
+			Description: "Use reaction with shield to impose disadvantage on an attack near you.",
 			Classes:     []string{"fighter", "paladin"},
 		},
 		{
 			Key:         "two_weapon_fighting",
 			Name:        "Two-Weapon Fighting",
-			Description: "When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack.",
+			Description: "Add ability modifier to off-hand weapon damage.",
 			Classes:     []string{"fighter", "ranger"},
 		},
 	}

--- a/internal/domain/rulebook/dnd5e/ranger_features.go
+++ b/internal/domain/rulebook/dnd5e/ranger_features.go
@@ -1,0 +1,49 @@
+package rulebook
+
+// GetFavoredEnemyChoice returns a FeatureChoice for ranger's favored enemy selection
+func GetFavoredEnemyChoice() *FeatureChoice {
+	return &FeatureChoice{
+		Type:        FeatureChoiceTypeFavoredEnemy,
+		FeatureKey:  "favored_enemy",
+		Name:        "Favored Enemy",
+		Description: "You have significant experience studying, tracking, hunting, and even talking to a certain type of enemy. You gain advantage on Wisdom (Survival) checks to track your favored enemies, as well as on Intelligence checks to recall information about them.",
+		Choose:      1,
+		Options: []FeatureOption{
+			{Key: "aberrations", Name: "Aberrations", Description: "Beholders, mind flayers, and other alien creatures"},
+			{Key: "beasts", Name: "Beasts", Description: "Bears, wolves, dire animals, and other natural creatures"},
+			{Key: "celestials", Name: "Celestials", Description: "Angels, pegasi, unicorns, and other heavenly beings"},
+			{Key: "constructs", Name: "Constructs", Description: "Golems, animated objects, and other artificial creatures"},
+			{Key: "dragons", Name: "Dragons", Description: "True dragons and dragonkin"},
+			{Key: "elementals", Name: "Elementals", Description: "Creatures from the elemental planes"},
+			{Key: "fey", Name: "Fey", Description: "Sprites, dryads, pixies, and other fey creatures"},
+			{Key: "fiends", Name: "Fiends", Description: "Devils, demons, yugoloths, and other evil outsiders"},
+			{Key: "giants", Name: "Giants", Description: "Hill giants, storm giants, ogres, and other large humanoids"},
+			{Key: "monstrosities", Name: "Monstrosities", Description: "Griffons, hydras, owlbears, and other unnatural creatures"},
+			{Key: "oozes", Name: "Oozes", Description: "Black puddings, gelatinous cubes, and other amorphous creatures"},
+			{Key: "plants", Name: "Plants", Description: "Shambling mounds, treants, and other plant creatures"},
+			{Key: "undead", Name: "Undead", Description: "Zombies, skeletons, vampires, and other undead"},
+			{Key: "humanoids", Name: "Two Humanoid Races", Description: "Choose two races of humanoid (such as gnolls and orcs)"},
+		},
+	}
+}
+
+// GetNaturalExplorerChoice returns a FeatureChoice for ranger's natural explorer selection
+func GetNaturalExplorerChoice() *FeatureChoice {
+	return &FeatureChoice{
+		Type:        FeatureChoiceTypeNaturalExplorer,
+		FeatureKey:  "natural_explorer",
+		Name:        "Natural Explorer",
+		Description: "You are particularly familiar with one type of natural environment and are adept at traveling and surviving in such regions. While traveling in your favored terrain, you gain various benefits.",
+		Choose:      1,
+		Options: []FeatureOption{
+			{Key: "arctic", Name: "Arctic", Description: "Frozen tundra, glaciers, and icy wastes"},
+			{Key: "coast", Name: "Coast", Description: "Beaches, cliffs, shores, and islands"},
+			{Key: "desert", Name: "Desert", Description: "Sandy and rocky badlands, hot and cold deserts"},
+			{Key: "forest", Name: "Forest", Description: "Woodlands, jungles, and rainforests"},
+			{Key: "grassland", Name: "Grassland", Description: "Plains, savannas, meadows, and prairies"},
+			{Key: "mountain", Name: "Mountain", Description: "Hills, peaks, and alpine regions"},
+			{Key: "swamp", Name: "Swamp", Description: "Marshes, bogs, fens, and moors"},
+			{Key: "underdark", Name: "Underdark", Description: "Caves, caverns, and underground passages"},
+		},
+	}
+}

--- a/internal/handlers/discord/dnd/character/class_features_divine_domain.go
+++ b/internal/handlers/discord/dnd/character/class_features_divine_domain.go
@@ -1,0 +1,119 @@
+package character
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	character2 "github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/rulebook/dnd5e"
+	"github.com/bwmarrin/discordgo"
+)
+
+// ShowDivineDomainSelection displays the divine domain selection UI
+func (h *ClassFeaturesHandler) ShowDivineDomainSelection(req *InteractionRequest) error {
+	// Get the character
+	char, err := h.characterService.GetByID(req.CharacterID)
+	if err != nil {
+		return fmt.Errorf("failed to get character: %w", err)
+	}
+
+	// Get pending feature choices to find the divine domain choice
+	ctx := context.TODO()
+	pendingChoices, err := h.characterService.GetPendingFeatureChoices(ctx, req.CharacterID)
+	if err != nil {
+		return fmt.Errorf("failed to get pending choices: %w", err)
+	}
+
+	// Find the divine domain choice
+	var domainChoice *rulebook.FeatureChoice
+	for _, choice := range pendingChoices {
+		if choice.Type == rulebook.FeatureChoiceTypeDivineDomain {
+			domainChoice = choice
+			break
+		}
+	}
+
+	if domainChoice == nil {
+		return fmt.Errorf("no divine domain choice found for character")
+	}
+
+	// Convert rulebook options to Discord select menu options
+	var domainOptions []discordgo.SelectMenuOption
+	for _, option := range domainChoice.Options {
+		domainOptions = append(domainOptions, discordgo.SelectMenuOption{
+			Label:       option.Name,
+			Value:       option.Key,
+			Description: option.Description,
+		})
+	}
+
+	// Create embed
+	embed := &discordgo.MessageEmbed{
+		Title:       fmt.Sprintf("Choose Your %s", domainChoice.Name),
+		Description: fmt.Sprintf("**%s**, %s", char.Name, domainChoice.Description),
+		Color:       0xFFD700, // Gold for cleric
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:   "Your Selection",
+				Value:  "Your choice grants you domain spells and other features when you reach certain levels.",
+				Inline: false,
+			},
+		},
+	}
+
+	// Add progress field
+	classKey := ""
+	if char.Class != nil {
+		classKey = char.Class.Key
+	}
+	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+		Name:   "Progress",
+		Value:  BuildProgressValue(classKey, "class_features"),
+		Inline: false,
+	})
+
+	// Create components
+	components := []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					CustomID:    fmt.Sprintf("character_create:class_features:%s:divine_domain", char.ID),
+					Placeholder: "Select your divine domain...",
+					Options:     domainOptions,
+				},
+			},
+		},
+	}
+
+	// Update the interaction response
+	return req.Session.InteractionRespond(req.Interaction.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Embeds:     []*discordgo.MessageEmbed{embed},
+			Components: components,
+			Flags:      discordgo.MessageFlagsEphemeral,
+		},
+	})
+}
+
+// handleDivineDomain stores the cleric's divine domain selection
+func (h *ClassFeaturesHandler) handleDivineDomain(req *ClassFeaturesRequest, char *character2.Character) error {
+	// Find the divine domain feature and update its metadata
+	for _, feature := range char.Features {
+		if feature.Key == "divine_domain" {
+			if feature.Metadata == nil {
+				feature.Metadata = make(map[string]any)
+			}
+			feature.Metadata["domain"] = req.Selection
+
+			// Log for debugging
+			log.Printf("Set divine domain for %s to %s", char.Name, req.Selection)
+
+			// TODO: Add domain spells to character's known spells when spellcasting is implemented
+			break
+		}
+	}
+
+	return nil
+}

--- a/internal/handlers/discord/handler.go
+++ b/internal/handlers/discord/handler.go
@@ -723,6 +723,10 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 								if err := h.characterClassFeaturesHandler.ShowFightingStyleSelection(req); err != nil {
 									log.Printf("Error showing fighting style selection: %v", err)
 								}
+							case "divine_domain":
+								if err := h.characterClassFeaturesHandler.ShowDivineDomainSelection(req); err != nil {
+									log.Printf("Error showing divine domain selection: %v", err)
+								}
 							default:
 								log.Printf("Unknown feature type to show: %s", featureType)
 							}
@@ -823,6 +827,10 @@ func (h *Handler) handleComponent(s *discordgo.Session, i *discordgo.Interaction
 									case "fighting_style":
 										if featErr := h.characterClassFeaturesHandler.ShowFightingStyleSelection(req); featErr != nil {
 											log.Printf("Error showing fighting style selection: %v", featErr)
+										}
+									case "divine_domain":
+										if featErr := h.characterClassFeaturesHandler.ShowDivineDomainSelection(req); featErr != nil {
+											log.Printf("Error showing divine domain selection: %v", featErr)
 										}
 									default:
 										log.Printf("Unknown feature type to show: %s", featureType)

--- a/internal/services/character/feature_choices_test.go
+++ b/internal/services/character/feature_choices_test.go
@@ -1,0 +1,237 @@
+package character_test
+
+import (
+	"context"
+	"testing"
+
+	mockdnd5e "github.com/KirkDiggler/dnd-bot-discord/internal/clients/dnd5e/mock"
+	charDomain "github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/rulebook/dnd5e"
+	mockcharrepo "github.com/KirkDiggler/dnd-bot-discord/internal/repositories/characters/mock"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/services/character"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetPendingFeatureChoices(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	mockRepo := mockcharrepo.NewMockRepository(ctrl)
+	mockDndClient := mockdnd5e.NewMockClient(ctrl)
+
+	svc := character.NewService(&character.ServiceConfig{
+		Repository: mockRepo,
+		DNDClient:  mockDndClient,
+	})
+
+	t.Run("Fighter with no fighting style selected", func(t *testing.T) {
+		// Create a fighter character with fighting_style feature but no selection
+		characterID := "fighter-123"
+		fighterChar := &charDomain.Character{
+			ID:    characterID,
+			Name:  "Test Fighter",
+			Level: 1,
+			Class: &rulebook.Class{
+				Key:  "fighter",
+				Name: "Fighter",
+			},
+			Features: []*rulebook.CharacterFeature{
+				{
+					Key:      "fighting_style",
+					Name:     "Fighting Style",
+					Type:     rulebook.FeatureTypeClass,
+					Metadata: nil, // No style selected yet
+				},
+			},
+		}
+
+		// Mock repository Get
+		mockRepo.EXPECT().
+			Get(ctx, characterID).
+			Return(fighterChar, nil)
+
+		// Get pending choices
+		choices, err := svc.GetPendingFeatureChoices(ctx, characterID)
+		require.NoError(t, err)
+		require.Len(t, choices, 1)
+
+		// Verify fighting style choice
+		choice := choices[0]
+		assert.Equal(t, rulebook.FeatureChoiceTypeFightingStyle, choice.Type)
+		assert.Equal(t, "fighting_style", choice.FeatureKey)
+		assert.Equal(t, "Fighting Style", choice.Name)
+		assert.Greater(t, len(choice.Options), 0)
+
+		// Verify some options exist
+		optionKeys := make(map[string]bool)
+		for _, opt := range choice.Options {
+			optionKeys[opt.Key] = true
+		}
+		assert.True(t, optionKeys["archery"])
+		assert.True(t, optionKeys["defense"])
+		assert.True(t, optionKeys["dueling"])
+	})
+
+	t.Run("Fighter with fighting style already selected", func(t *testing.T) {
+		// Create a fighter character with fighting style already selected
+		characterID := "fighter-456"
+		fighterChar := &charDomain.Character{
+			ID:    characterID,
+			Name:  "Test Fighter",
+			Level: 1,
+			Class: &rulebook.Class{
+				Key:  "fighter",
+				Name: "Fighter",
+			},
+			Features: []*rulebook.CharacterFeature{
+				{
+					Key:  "fighting_style",
+					Name: "Fighting Style",
+					Type: rulebook.FeatureTypeClass,
+					Metadata: map[string]any{
+						"style": "defense", // Already selected
+					},
+				},
+			},
+		}
+
+		// Mock repository Get
+		mockRepo.EXPECT().
+			Get(ctx, characterID).
+			Return(fighterChar, nil)
+
+		// Get pending choices
+		choices, err := svc.GetPendingFeatureChoices(ctx, characterID)
+		require.NoError(t, err)
+		assert.Empty(t, choices, "Should have no pending choices when style is already selected")
+	})
+
+	t.Run("Cleric with no divine domain selected", func(t *testing.T) {
+		// Create a cleric character with divine_domain feature but no selection
+		characterID := "cleric-123"
+		clericChar := &charDomain.Character{
+			ID:    characterID,
+			Name:  "Test Cleric",
+			Level: 1,
+			Class: &rulebook.Class{
+				Key:  "cleric",
+				Name: "Cleric",
+			},
+			Features: []*rulebook.CharacterFeature{
+				{
+					Key:      "divine_domain",
+					Name:     "Divine Domain",
+					Type:     rulebook.FeatureTypeClass,
+					Metadata: nil, // No domain selected yet
+				},
+			},
+		}
+
+		// Mock repository Get
+		mockRepo.EXPECT().
+			Get(ctx, characterID).
+			Return(clericChar, nil)
+
+		// Get pending choices
+		choices, err := svc.GetPendingFeatureChoices(ctx, characterID)
+		require.NoError(t, err)
+		require.Len(t, choices, 1)
+
+		// Verify divine domain choice
+		choice := choices[0]
+		assert.Equal(t, rulebook.FeatureChoiceTypeDivineDomain, choice.Type)
+		assert.Equal(t, "divine_domain", choice.FeatureKey)
+		assert.Equal(t, "Divine Domain", choice.Name)
+		assert.Len(t, choice.Options, 7) // 7 PHB domains
+
+		// Verify all domains are present
+		domainKeys := make(map[string]bool)
+		for _, opt := range choice.Options {
+			domainKeys[opt.Key] = true
+		}
+		assert.True(t, domainKeys["knowledge"])
+		assert.True(t, domainKeys["life"])
+		assert.True(t, domainKeys["light"])
+		assert.True(t, domainKeys["nature"])
+		assert.True(t, domainKeys["tempest"])
+		assert.True(t, domainKeys["trickery"])
+		assert.True(t, domainKeys["war"])
+	})
+
+	t.Run("Ranger with both features missing", func(t *testing.T) {
+		// Create a ranger character with neither feature selected
+		characterID := "ranger-123"
+		rangerChar := &charDomain.Character{
+			ID:    characterID,
+			Name:  "Test Ranger",
+			Level: 1,
+			Class: &rulebook.Class{
+				Key:  "ranger",
+				Name: "Ranger",
+			},
+			Features: []*rulebook.CharacterFeature{
+				{
+					Key:      "favored_enemy",
+					Name:     "Favored Enemy",
+					Type:     rulebook.FeatureTypeClass,
+					Metadata: nil, // No enemy selected
+				},
+				{
+					Key:      "natural_explorer",
+					Name:     "Natural Explorer",
+					Type:     rulebook.FeatureTypeClass,
+					Metadata: nil, // No terrain selected
+				},
+			},
+		}
+
+		// Mock repository Get
+		mockRepo.EXPECT().
+			Get(ctx, characterID).
+			Return(rangerChar, nil)
+
+		// Get pending choices
+		choices, err := svc.GetPendingFeatureChoices(ctx, characterID)
+		require.NoError(t, err)
+		assert.Len(t, choices, 2, "Ranger should have 2 pending choices")
+
+		// Check both choices are present
+		choiceTypes := make(map[rulebook.FeatureChoiceType]bool)
+		for _, choice := range choices {
+			choiceTypes[choice.Type] = true
+		}
+		assert.True(t, choiceTypes[rulebook.FeatureChoiceTypeFavoredEnemy])
+		assert.True(t, choiceTypes[rulebook.FeatureChoiceTypeNaturalExplorer])
+	})
+
+	t.Run("Character with no class", func(t *testing.T) {
+		// Create a character with no class
+		characterID := "no-class-123"
+		char := &charDomain.Character{
+			ID:    characterID,
+			Name:  "Test Character",
+			Level: 1,
+			Class: nil, // No class
+		}
+
+		// Mock repository Get
+		mockRepo.EXPECT().
+			Get(ctx, characterID).
+			Return(char, nil)
+
+		// Get pending choices
+		choices, err := svc.GetPendingFeatureChoices(ctx, characterID)
+		require.NoError(t, err)
+		assert.Empty(t, choices, "Should have no choices without a class")
+	})
+
+	t.Run("Invalid character ID", func(t *testing.T) {
+		// Test with empty character ID
+		choices, err := svc.GetPendingFeatureChoices(ctx, "")
+		assert.Error(t, err)
+		assert.Nil(t, choices)
+	})
+}

--- a/internal/services/character/mock/mock_service.go
+++ b/internal/services/character/mock/mock_service.go
@@ -239,6 +239,21 @@ func (mr *MockServiceMockRecorder) GetOrCreateDraftCharacter(ctx, userID, realmI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateDraftCharacter", reflect.TypeOf((*MockService)(nil).GetOrCreateDraftCharacter), ctx, userID, realmID)
 }
 
+// GetPendingFeatureChoices mocks base method.
+func (m *MockService) GetPendingFeatureChoices(ctx context.Context, characterID string) ([]*rulebook.FeatureChoice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPendingFeatureChoices", ctx, characterID)
+	ret0, _ := ret[0].([]*rulebook.FeatureChoice)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPendingFeatureChoices indicates an expected call of GetPendingFeatureChoices.
+func (mr *MockServiceMockRecorder) GetPendingFeatureChoices(ctx, characterID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingFeatureChoices", reflect.TypeOf((*MockService)(nil).GetPendingFeatureChoices), ctx, characterID)
+}
+
 // GetRace mocks base method.
 func (m *MockService) GetRace(ctx context.Context, raceKey string) (*rulebook.Race, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary
This PR fixes the "interaction failed" error that occurs when confirming ability scores during character creation. The error was caused by fighting style descriptions exceeding Discord's 100 character limit for select menu options.

## Problem
When creating a Fighter character and confirming ability scores, the bot would fail with a Discord API error about description length exceeding 100 characters.

## Solution
Shortened all fighting style descriptions to be under 100 characters while maintaining clarity:
- **Dueling**: 124 → 73 chars
- **Great Weapon Fighting**: 228 → 63 chars  
- **Protection**: 189 → 70 chars
- **Two-Weapon Fighting**: 109 → 47 chars

## Testing
- All descriptions verified to be under 100 characters
- Character creation flow should now proceed without errors
- All unit tests passing

## Related
- This fix is needed for PR #279 to work properly in production
- Should be merged before #279 if possible