### PR TITLE
fix: Display divine domain selection on character sheet

### DIFF
--- a/internal/handlers/discord/dnd/character/sheet.go
+++ b/internal/handlers/discord/dnd/character/sheet.go
@@ -330,6 +330,30 @@ func buildFeatureSummary(char *character.Character) []string {
 					}
 					featName = fmt.Sprintf("%s (%s)", feat.Name, styleDisplay)
 				}
+			} else if feat.Key == "divine_domain" && feat.Metadata != nil {
+				if domain, ok := feat.Metadata["domain"].(string); ok {
+					// Format divine domain for display
+					domainDisplay := ""
+					switch domain {
+					case "knowledge":
+						domainDisplay = "Knowledge"
+					case "life":
+						domainDisplay = "Life"
+					case "light":
+						domainDisplay = "Light"
+					case "nature":
+						domainDisplay = "Nature"
+					case "tempest":
+						domainDisplay = "Tempest"
+					case "trickery":
+						domainDisplay = "Trickery"
+					case "war":
+						domainDisplay = "War"
+					default:
+						domainDisplay = caser.String(domain)
+					}
+					featName = fmt.Sprintf("%s (%s)", feat.Name, domainDisplay)
+				}
 			}
 			lines = append(lines, fmt.Sprintf("• %s", featName))
 		}

--- a/internal/handlers/discord/dnd/character/sheet_cleric_test.go
+++ b/internal/handlers/discord/dnd/character/sheet_cleric_test.go
@@ -1,0 +1,120 @@
+package character
+
+import (
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/rulebook/dnd5e"
+	"strings"
+	"testing"
+)
+
+func TestBuildFeatureSummary_ClericWithDivineDomain(t *testing.T) {
+	// Create a cleric character with divine domain selection
+	cleric := &character.Character{
+		Name:  "Test Cleric",
+		Level: 1,
+		Features: []*rulebook.CharacterFeature{
+			{
+				Key:         "divine_domain",
+				Name:        "Divine Domain",
+				Type:        rulebook.FeatureTypeClass,
+				Description: "Choose one domain related to your deity.",
+				Metadata: map[string]any{
+					"domain": "life",
+				},
+			},
+		},
+	}
+
+	lines := buildFeatureSummary(cleric)
+
+	// Check that the feature shows the selected domain
+	foundDivineDomain := false
+	for _, line := range lines {
+		if strings.Contains(line, "Divine Domain (Life)") {
+			foundDivineDomain = true
+		}
+	}
+
+	if !foundDivineDomain {
+		t.Errorf("Expected to find 'Divine Domain (Life)' in feature summary, got: %v", lines)
+	}
+}
+
+func TestBuildFeatureSummary_ClericAllDomains(t *testing.T) {
+	// Test all domain names are properly capitalized
+	domains := map[string]string{
+		"knowledge": "Knowledge",
+		"life":      "Life",
+		"light":     "Light",
+		"nature":    "Nature",
+		"tempest":   "Tempest",
+		"trickery":  "Trickery",
+		"war":       "War",
+	}
+
+	for domainKey, expectedDisplay := range domains {
+		cleric := &character.Character{
+			Name:  "Test Cleric",
+			Level: 1,
+			Features: []*rulebook.CharacterFeature{
+				{
+					Key:         "divine_domain",
+					Name:        "Divine Domain",
+					Type:        rulebook.FeatureTypeClass,
+					Description: "Choose one domain related to your deity.",
+					Metadata: map[string]any{
+						"domain": domainKey,
+					},
+				},
+			},
+		}
+
+		lines := buildFeatureSummary(cleric)
+
+		// Check that the feature shows the properly formatted domain
+		expectedText := "Divine Domain (" + expectedDisplay + ")"
+		foundDomain := false
+		for _, line := range lines {
+			if strings.Contains(line, expectedText) {
+				foundDomain = true
+				break
+			}
+		}
+
+		if !foundDomain {
+			t.Errorf("Expected to find '%s' in feature summary for domain '%s', got: %v",
+				expectedText, domainKey, lines)
+		}
+	}
+}
+
+func TestBuildFeatureSummary_ClericWithoutDomain(t *testing.T) {
+	// Create a cleric character without domain metadata (shouldn't crash)
+	cleric := &character.Character{
+		Name:  "Test Cleric",
+		Level: 1,
+		Features: []*rulebook.CharacterFeature{
+			{
+				Key:         "divine_domain",
+				Name:        "Divine Domain",
+				Type:        rulebook.FeatureTypeClass,
+				Description: "Choose one domain related to your deity.",
+				// No metadata
+			},
+		},
+	}
+
+	lines := buildFeatureSummary(cleric)
+
+	// Should still show the feature, just without the selection
+	foundDivineDomain := false
+	for _, line := range lines {
+		if strings.Contains(line, "Divine Domain") && !strings.Contains(line, "(") {
+			foundDivineDomain = true
+		}
+	}
+
+	if !foundDivineDomain {
+		t.Errorf("Expected to find 'Divine Domain' in feature summary, got: %v", lines)
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes the issue where Cleric divine domain selections were being saved but not displayed on the character sheet.

## Problem
When a Cleric selected their divine domain (e.g., Life, Knowledge, War), the selection was properly saved to the character data but was not visible when viewing the character sheet. The sheet would only show "Divine Domain" without indicating which domain was selected.

## Solution
Added handling for `divine_domain` in the `buildFeatureSummary` function to display the selected domain in parentheses, matching the pattern used for other class feature selections like fighting styles.

## Changes
- Added divine domain case to `buildFeatureSummary` in `sheet.go`
- Formats all 7 PHB domains with proper capitalization
- Created comprehensive tests in `sheet_cleric_test.go`
- Handles cases where domain hasn't been selected yet

## Testing
- Added unit tests for all domain display scenarios
- Tests verify proper capitalization for all 7 domains
- Tests handle missing metadata gracefully
- All tests passing

## Result
Clerics will now see their domain selection on the character sheet:
- Before: "• Divine Domain"
- After: "• Divine Domain (Life)"

This matches the display pattern for other class feature selections like:
- "• Fighting Style (Defense)"
- "• Favored Enemy (Undead)"
- "• Natural Explorer (Forest)"