### PR TITLE
refactor: simplify feature display to use metadata rendering

### DIFF
--- a/internal/handlers/discord/dnd/character/class_features_divine_domain.go
+++ b/internal/handlers/discord/dnd/character/class_features_divine_domain.go
@@ -99,21 +99,29 @@ func (h *ClassFeaturesHandler) ShowDivineDomainSelection(req *InteractionRequest
 
 // handleDivineDomain stores the cleric's divine domain selection
 func (h *ClassFeaturesHandler) handleDivineDomain(req *ClassFeaturesRequest, char *character2.Character) error {
-	// Find the divine domain feature and update its metadata
-	for _, feature := range char.Features {
-		if feature.Key == "divine_domain" {
-			if feature.Metadata == nil {
-				feature.Metadata = make(map[string]any)
-			}
-			feature.Metadata["domain"] = req.Selection
-
-			// Log for debugging
-			log.Printf("Set divine domain for %s to %s", char.Name, req.Selection)
-
-			// TODO: Add domain spells to character's known spells when spellcasting is implemented
+	// Get the divine domains to find the display name
+	domains := rulebook.GetDivineDomains()
+	var selectedName string
+	for _, domain := range domains {
+		if domain.Key == req.Selection {
+			selectedName = domain.Name
 			break
 		}
 	}
+
+	// If we couldn't find the display name, use the key
+	if selectedName == "" {
+		selectedName = req.Selection
+	}
+
+	// Find the divine domain feature and update its metadata
+	updateFeatureMetadata(char, "divine_domain", map[string]any{
+		"domain":            req.Selection,
+		"selection_display": selectedName,
+	})
+	log.Printf("Set divine domain for %s to %s", char.Name, selectedName)
+
+	// TODO: Add domain spells to character's known spells when spellcasting is implemented
 
 	return nil
 }

--- a/internal/handlers/discord/dnd/character/sheet.go
+++ b/internal/handlers/discord/dnd/character/sheet.go
@@ -13,8 +13,6 @@ import (
 	"github.com/KirkDiggler/dnd-bot-discord/internal/handlers/discord/utils"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/services"
 	"github.com/bwmarrin/discordgo"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 // SheetHandler handles the character sheet display command
@@ -289,70 +287,12 @@ func buildFeatureSummary(char *character.Character) []string {
 	// Add class features
 	if len(classFeatures) > 0 {
 		lines = append(lines, "**Class Features:**")
-		caser := cases.Title(language.English)
 		for _, feat := range classFeatures {
 			featName := feat.Name
-			// Add specific selections from metadata
-			if feat.Key == "favored_enemy" && feat.Metadata != nil {
-				if enemyType, ok := feat.Metadata["enemy_type"].(string); ok {
-					// Capitalize the enemy type for display
-					enemyDisplay := caser.String(enemyType)
-					if enemyType == "humanoids" {
-						enemyDisplay = "Two Humanoid Races"
-					}
-					featName = fmt.Sprintf("%s (%s)", feat.Name, enemyDisplay)
-				}
-			} else if feat.Key == "natural_explorer" && feat.Metadata != nil {
-				if terrainType, ok := feat.Metadata["terrain_type"].(string); ok {
-					// Capitalize the terrain type
-					terrainDisplay := caser.String(terrainType)
-					featName = fmt.Sprintf("%s (%s)", feat.Name, terrainDisplay)
-				}
-			} else if feat.Key == "fighting_style" && feat.Metadata != nil {
-				if style, ok := feat.Metadata["style"].(string); ok {
-					// Format fighting style for display
-					styleDisplay := ""
-					switch style {
-					case "archery":
-						styleDisplay = "Archery"
-					case "defense":
-						styleDisplay = "Defense"
-					case "dueling":
-						styleDisplay = "Dueling"
-					case "great_weapon":
-						styleDisplay = "Great Weapon Fighting"
-					case "protection":
-						styleDisplay = "Protection"
-					case "two_weapon":
-						styleDisplay = "Two-Weapon Fighting"
-					default:
-						styleDisplay = caser.String(style)
-					}
-					featName = fmt.Sprintf("%s (%s)", feat.Name, styleDisplay)
-				}
-			} else if feat.Key == "divine_domain" && feat.Metadata != nil {
-				if domain, ok := feat.Metadata["domain"].(string); ok {
-					// Format divine domain for display
-					domainDisplay := ""
-					switch domain {
-					case "knowledge":
-						domainDisplay = "Knowledge"
-					case "life":
-						domainDisplay = "Life"
-					case "light":
-						domainDisplay = "Light"
-					case "nature":
-						domainDisplay = "Nature"
-					case "tempest":
-						domainDisplay = "Tempest"
-					case "trickery":
-						domainDisplay = "Trickery"
-					case "war":
-						domainDisplay = "War"
-					default:
-						domainDisplay = caser.String(domain)
-					}
-					featName = fmt.Sprintf("%s (%s)", feat.Name, domainDisplay)
+			// If there's a selection display in metadata, append it
+			if feat.Metadata != nil {
+				if selection, ok := feat.Metadata["selection_display"].(string); ok && selection != "" {
+					featName = fmt.Sprintf("%s (%s)", feat.Name, selection)
 				}
 			}
 			lines = append(lines, fmt.Sprintf("• %s", featName))

--- a/internal/handlers/discord/dnd/character/sheet.go
+++ b/internal/handlers/discord/dnd/character/sheet.go
@@ -330,6 +330,30 @@ func buildFeatureSummary(char *character.Character) []string {
 					}
 					featName = fmt.Sprintf("%s (%s)", feat.Name, styleDisplay)
 				}
+			} else if feat.Key == "divine_domain" && feat.Metadata != nil {
+				if domain, ok := feat.Metadata["domain"].(string); ok {
+					// Format divine domain for display
+					domainDisplay := ""
+					switch domain {
+					case "knowledge":
+						domainDisplay = "Knowledge"
+					case "life":
+						domainDisplay = "Life"
+					case "light":
+						domainDisplay = "Light"
+					case "nature":
+						domainDisplay = "Nature"
+					case "tempest":
+						domainDisplay = "Tempest"
+					case "trickery":
+						domainDisplay = "Trickery"
+					case "war":
+						domainDisplay = "War"
+					default:
+						domainDisplay = caser.String(domain)
+					}
+					featName = fmt.Sprintf("%s (%s)", feat.Name, domainDisplay)
+				}
 			}
 			lines = append(lines, fmt.Sprintf("• %s", featName))
 		}

--- a/internal/handlers/discord/dnd/character/sheet_cleric_test.go
+++ b/internal/handlers/discord/dnd/character/sheet_cleric_test.go
@@ -1,0 +1,120 @@
+package character
+
+import (
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/rulebook/dnd5e"
+	"strings"
+	"testing"
+)
+
+func TestBuildFeatureSummary_ClericWithDivineDomain(t *testing.T) {
+	// Create a cleric character with divine domain selection
+	cleric := &character.Character{
+		Name:  "Test Cleric",
+		Level: 1,
+		Features: []*rulebook.CharacterFeature{
+			{
+				Key:         "divine_domain",
+				Name:        "Divine Domain",
+				Type:        rulebook.FeatureTypeClass,
+				Description: "Choose one domain related to your deity.",
+				Metadata: map[string]any{
+					"domain": "life",
+				},
+			},
+		},
+	}
+
+	lines := buildFeatureSummary(cleric)
+
+	// Check that the feature shows the selected domain
+	foundDivineDomain := false
+	for _, line := range lines {
+		if strings.Contains(line, "Divine Domain (Life)") {
+			foundDivineDomain = true
+		}
+	}
+
+	if !foundDivineDomain {
+		t.Errorf("Expected to find 'Divine Domain (Life)' in feature summary, got: %v", lines)
+	}
+}
+
+func TestBuildFeatureSummary_ClericAllDomains(t *testing.T) {
+	// Test all domain names are properly capitalized
+	domains := map[string]string{
+		"knowledge": "Knowledge",
+		"life":      "Life",
+		"light":     "Light",
+		"nature":    "Nature",
+		"tempest":   "Tempest",
+		"trickery":  "Trickery",
+		"war":       "War",
+	}
+
+	for domainKey, expectedDisplay := range domains {
+		cleric := &character.Character{
+			Name:  "Test Cleric",
+			Level: 1,
+			Features: []*rulebook.CharacterFeature{
+				{
+					Key:         "divine_domain",
+					Name:        "Divine Domain",
+					Type:        rulebook.FeatureTypeClass,
+					Description: "Choose one domain related to your deity.",
+					Metadata: map[string]any{
+						"domain": domainKey,
+					},
+				},
+			},
+		}
+
+		lines := buildFeatureSummary(cleric)
+
+		// Check that the feature shows the properly formatted domain
+		expectedText := "Divine Domain (" + expectedDisplay + ")"
+		foundDomain := false
+		for _, line := range lines {
+			if strings.Contains(line, expectedText) {
+				foundDomain = true
+				break
+			}
+		}
+
+		if !foundDomain {
+			t.Errorf("Expected to find '%s' in feature summary for domain '%s', got: %v",
+				expectedText, domainKey, lines)
+		}
+	}
+}
+
+func TestBuildFeatureSummary_ClericWithoutDomain(t *testing.T) {
+	// Create a cleric character without domain metadata (shouldn't crash)
+	cleric := &character.Character{
+		Name:  "Test Cleric",
+		Level: 1,
+		Features: []*rulebook.CharacterFeature{
+			{
+				Key:         "divine_domain",
+				Name:        "Divine Domain",
+				Type:        rulebook.FeatureTypeClass,
+				Description: "Choose one domain related to your deity.",
+				// No metadata
+			},
+		},
+	}
+
+	lines := buildFeatureSummary(cleric)
+
+	// Should still show the feature, just without the selection
+	foundDivineDomain := false
+	for _, line := range lines {
+		if strings.Contains(line, "Divine Domain") && !strings.Contains(line, "(") {
+			foundDivineDomain = true
+		}
+	}
+
+	if !foundDivineDomain {
+		t.Errorf("Expected to find 'Divine Domain' in feature summary, got: %v", lines)
+	}
+}

--- a/internal/handlers/discord/dnd/character/sheet_cleric_test.go
+++ b/internal/handlers/discord/dnd/character/sheet_cleric_test.go
@@ -2,7 +2,7 @@ package character
 
 import (
 	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
-	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/rulebook/dnd5e"
+	rulebook "github.com/KirkDiggler/dnd-bot-discord/internal/domain/rulebook/dnd5e"
 	"strings"
 	"testing"
 )
@@ -19,7 +19,8 @@ func TestBuildFeatureSummary_ClericWithDivineDomain(t *testing.T) {
 				Type:        rulebook.FeatureTypeClass,
 				Description: "Choose one domain related to your deity.",
 				Metadata: map[string]any{
-					"domain": "life",
+					"domain":            "life",
+					"selection_display": "Life Domain",
 				},
 			},
 		},
@@ -30,61 +31,48 @@ func TestBuildFeatureSummary_ClericWithDivineDomain(t *testing.T) {
 	// Check that the feature shows the selected domain
 	foundDivineDomain := false
 	for _, line := range lines {
-		if strings.Contains(line, "Divine Domain (Life)") {
+		if strings.Contains(line, "Divine Domain (Life Domain)") {
 			foundDivineDomain = true
 		}
 	}
 
 	if !foundDivineDomain {
-		t.Errorf("Expected to find 'Divine Domain (Life)' in feature summary, got: %v", lines)
+		t.Errorf("Expected to find 'Divine Domain (Life Domain)' in feature summary, got: %v", lines)
 	}
 }
 
-func TestBuildFeatureSummary_ClericAllDomains(t *testing.T) {
-	// Test all domain names are properly capitalized
-	domains := map[string]string{
-		"knowledge": "Knowledge",
-		"life":      "Life",
-		"light":     "Light",
-		"nature":    "Nature",
-		"tempest":   "Tempest",
-		"trickery":  "Trickery",
-		"war":       "War",
-	}
-
-	for domainKey, expectedDisplay := range domains {
-		cleric := &character.Character{
-			Name:  "Test Cleric",
-			Level: 1,
-			Features: []*rulebook.CharacterFeature{
-				{
-					Key:         "divine_domain",
-					Name:        "Divine Domain",
-					Type:        rulebook.FeatureTypeClass,
-					Description: "Choose one domain related to your deity.",
-					Metadata: map[string]any{
-						"domain": domainKey,
-					},
+func TestBuildFeatureSummary_WithSelectionDisplay(t *testing.T) {
+	// Test that the handler properly renders whatever is in selection_display
+	char := &character.Character{
+		Name:  "Test Character",
+		Level: 1,
+		Features: []*rulebook.CharacterFeature{
+			{
+				Key:         "some_feature",
+				Name:        "Some Feature",
+				Type:        rulebook.FeatureTypeClass,
+				Description: "A feature with a selection",
+				Metadata: map[string]any{
+					"selection_key":     "some_key",
+					"selection_display": "Display Name",
 				},
 			},
-		}
+		},
+	}
 
-		lines := buildFeatureSummary(cleric)
+	lines := buildFeatureSummary(char)
 
-		// Check that the feature shows the properly formatted domain
-		expectedText := "Divine Domain (" + expectedDisplay + ")"
-		foundDomain := false
-		for _, line := range lines {
-			if strings.Contains(line, expectedText) {
-				foundDomain = true
-				break
-			}
+	// Check that the feature shows the selection display
+	foundFeature := false
+	for _, line := range lines {
+		if strings.Contains(line, "Some Feature (Display Name)") {
+			foundFeature = true
+			break
 		}
+	}
 
-		if !foundDomain {
-			t.Errorf("Expected to find '%s' in feature summary for domain '%s', got: %v",
-				expectedText, domainKey, lines)
-		}
+	if !foundFeature {
+		t.Errorf("Expected to find 'Some Feature (Display Name)' in feature summary, got: %v", lines)
 	}
 }
 

--- a/internal/handlers/discord/dnd/character/sheet_ranger_test.go
+++ b/internal/handlers/discord/dnd/character/sheet_ranger_test.go
@@ -19,7 +19,8 @@ func TestBuildFeatureSummary_RangerWithSelections(t *testing.T) {
 				Type:        rulebook.FeatureTypeClass,
 				Description: "You have significant experience studying, tracking, hunting, and even talking to a certain type of enemy.",
 				Metadata: map[string]any{
-					"enemy_type": "undead",
+					"enemy_type":        "undead",
+					"selection_display": "Undead",
 				},
 			},
 			{
@@ -28,7 +29,8 @@ func TestBuildFeatureSummary_RangerWithSelections(t *testing.T) {
 				Type:        rulebook.FeatureTypeClass,
 				Description: "You are particularly familiar with one type of natural environment and are adept at traveling and surviving in such regions.",
 				Metadata: map[string]any{
-					"terrain_type": "forest",
+					"terrain_type":      "forest",
+					"selection_display": "Forest",
 				},
 			},
 		},
@@ -54,7 +56,7 @@ func TestBuildFeatureSummary_RangerWithSelections(t *testing.T) {
 	}
 
 	if !foundNaturalExplorer {
-		t.Errorf("Expected to find 'Natural Explorer (forest)' in feature summary, got: %v", lines)
+		t.Errorf("Expected to find 'Natural Explorer (Forest)' in feature summary, got: %v", lines)
 	}
 }
 
@@ -101,7 +103,8 @@ func TestBuildFeatureSummary_RangerHumanoids(t *testing.T) {
 				Type:        rulebook.FeatureTypeClass,
 				Description: "You have significant experience studying, tracking, hunting, and even talking to a certain type of enemy.",
 				Metadata: map[string]any{
-					"enemy_type": "humanoids",
+					"enemy_type":        "humanoids",
+					"selection_display": "Two Humanoid Races",
 				},
 			},
 		},


### PR DESCRIPTION
Refactors the character sheet feature display to use a simple metadata-driven approach, removing complex logic from handlers.

## Changes
- Remove complex switch logic from sheet.go buildFeatureSummary()
- Use simple metadata["selection_display"] approach for showing feature selections
- Update all feature handlers to store display names in metadata
- Add updateFeatureMetadata() helper to reduce code duplication
- Fix linting issues (importShadow, nestingReduce)
- Update tests to use new simplified approach

## Motivation
Per user feedback: "handler should just render whatever it finds. checking it the way we are is logic that does not belong in the handler"

This change moves us toward a cleaner separation where:
- Handlers are responsible only for rendering
- Business logic and data transformation happen in the service layer
- Feature selections are stored in a consistent, extensible way

## Testing
- All unit tests pass ✅
- Linting clean ✅
- Pre-commit hooks pass ✅

## Next Steps
This sets us up well for #284 (service-driven character creation flow) by establishing the pattern of handlers as simple renderers.

Fixes #279