### PR TITLE
feat: Implement wizard spell selection in character creation

### DIFF
--- a/internal/domain/character/creation_step.go
+++ b/internal/domain/character/creation_step.go
@@ -14,6 +14,7 @@ const (
 	StepTypeDivineDomainSelection    CreationStepType = "divine_domain_selection"
 	StepTypeFavoredEnemySelection    CreationStepType = "favored_enemy_selection"
 	StepTypeNaturalExplorerSelection CreationStepType = "natural_explorer_selection"
+	StepTypeSpellSelection           CreationStepType = "spell_selection"
 	StepTypeProficiencySelection     CreationStepType = "proficiency_selection"
 	StepTypeEquipmentSelection       CreationStepType = "equipment_selection"
 	StepTypeCharacterDetails         CreationStepType = "character_details"

--- a/internal/handlers/discord/dnd/character/flow_handler.go
+++ b/internal/handlers/discord/dnd/character/flow_handler.go
@@ -84,6 +84,16 @@ func (h *FlowHandler) HandleSelection(s *discordgo.Session, i *discordgo.Interac
 			Selections: selections,
 		}
 
+		// Get the current step to check for context metadata
+		currentStep, err := h.services.CreationFlowService.GetCurrentStep(ctx, characterID)
+		if err == nil && currentStep != nil && currentStep.Context != nil {
+			// Pass through context metadata (like spell source)
+			result.Metadata = make(map[string]any)
+			if source, ok := currentStep.Context["source"]; ok {
+				result.Metadata["source"] = source
+			}
+		}
+
 		// Process the result and get next step
 		nextStep, err := h.services.CreationFlowService.ProcessStepResult(ctx, characterID, result)
 		if err != nil {
@@ -248,7 +258,8 @@ func (h *FlowHandler) routeToStepHandler(s *discordgo.Session, i *discordgo.Inte
 
 	// New step types that need generic rendering
 	case character.StepTypeSkillSelection,
-		character.StepTypeLanguageSelection:
+		character.StepTypeLanguageSelection,
+		character.StepTypeSpellSelection:
 		return h.renderGenericStep(s, i, step, characterID)
 
 	default:


### PR DESCRIPTION
This PR adds spell selection functionality for wizard characters during character creation.

## Changes
- Added `StepTypeSpellSelection` to the creation flow system
- Implemented wizard spell selection step (choose 6 1st-level spells)
- Fetches spell list from D&D API showing school and casting time
- Selected spells are stored in character's known spells list
- Added spell selection processing in CreationFlowService
- Added completion checks based on class spell requirements

## Technical Details
- Wizards start with 6 spells in their spellbook
- Spell descriptions show school and casting time (truncated for Discord's 100 char limit)
- Context metadata tracks spell source (e.g., "wizard_spellbook")
- Other casters (Sorcerer, Bard, Warlock) can be added similarly

## Testing
1. Create a wizard character
2. Progress through race/class selection
3. After abilities, you'll see "Choose Spells for Your Spellbook"
4. Select 6 spells from the dropdown
5. Spells are saved to character data

## Future Enhancements
- Add spell details view button for full spell descriptions
- Implement spell selection for other casters (Sorcerer: 2, Bard: 4, Warlock: 2)
- Add cantrip selection
- Consider spell preparation UI for prepared casters

Fixes #caster-3