### PR TITLE
feat: Implement ability score assignment with manual selection UI

### DIFF
--- a/internal/discord/v2/routers/create.go
+++ b/internal/discord/v2/routers/create.go
@@ -81,7 +81,6 @@ func (r *CreateRouter) registerRoutes() {
 	// Core flow components
 	r.router.ComponentFunc("select", r.creationHandler.HandleStepSelection)
 	r.router.ComponentFunc("back", r.creationHandler.HandleStepSelection)
-	r.router.ComponentFunc("roll", r.creationHandler.HandleStepSelection)
 	r.router.ComponentFunc("assign", r.creationHandler.HandleStepSelection)
 	r.router.ComponentFunc("proficiencies", r.creationHandler.HandleStepSelection)
 	r.router.ComponentFunc("equipment", r.creationHandler.HandleStepSelection)
@@ -93,6 +92,29 @@ func (r *CreateRouter) registerRoutes() {
 	r.router.ComponentFunc("race_random", r.creationHandler.HandleRandomRace)
 	r.router.ComponentFunc("preview_race", r.creationHandler.HandleRacePreview)
 	r.router.ComponentFunc("confirm_race", r.creationHandler.HandleConfirmRace)
+
+	// Ability scores handlers
+	r.router.ComponentFunc("roll", r.creationHandler.HandleRollAbilityScores)
+	r.router.ComponentFunc("standard", r.creationHandler.HandleStandardArray)
+	r.router.ComponentFunc("ability_info", r.creationHandler.HandleAbilityInfo)
+	r.router.ComponentFunc("confirm_rolled_scores", r.creationHandler.HandleConfirmRolledScores)
+	r.router.ComponentFunc("assign_standard_array", r.creationHandler.HandleAssignStandardArray)
+	r.router.ComponentFunc("start_ability_assignment", r.creationHandler.HandleStartAbilityAssignment)
+	r.router.ComponentFunc("start_fresh", r.creationHandler.HandleStartFresh)
+	r.router.ComponentFunc("back_to_abilities", r.creationHandler.HandleBackToAbilities)
+
+	// Manual assignment handlers
+	r.router.ComponentFunc("auto_assign_and_continue", r.creationHandler.HandleAutoAssignAndContinue)
+	r.router.ComponentFunc("start_manual_assignment", r.creationHandler.HandleStartManualAssignment)
+	r.router.ComponentFunc("assign_to_ability", r.creationHandler.HandleAssignToAbility)
+	r.router.ComponentFunc("apply_ability_assignment", r.creationHandler.HandleApplyAbilityAssignment)
+	r.router.ComponentFunc("apply_direct_assignment", r.creationHandler.HandleApplyDirectAssignment)
+	r.router.ComponentFunc("confirm_ability_assignment", r.creationHandler.HandleConfirmAbilityAssignment)
+
+	// One-at-a-time rolling handlers
+	r.router.ComponentFunc("roll_single_ability", r.creationHandler.HandleRollSingleAbility)
+	r.router.ComponentFunc("continue_rolling", r.creationHandler.HandleContinueRolling)
+	r.router.ComponentFunc("start_interactive_assignment", r.creationHandler.HandleStartInteractiveAssignment)
 
 	// Future: /dnd create encounter, /dnd create item, etc.
 	// r.router.ActionFunc("encounter", r.handleCreateEncounter)

--- a/internal/services/character/creation_flow_service.go
+++ b/internal/services/character/creation_flow_service.go
@@ -176,7 +176,8 @@ func (s *CreationFlowServiceImpl) isStepComplete(char *character.Character, step
 	case character.StepTypeClassSelection:
 		return char.Class != nil
 	case character.StepTypeAbilityScores:
-		return len(char.Attributes) > 0
+		// Check if abilities have been rolled (not if they're assigned to attributes)
+		return len(char.AbilityRolls) >= 6
 	case character.StepTypeAbilityAssignment:
 		// Check if all ability scores are assigned (not default values)
 		return s.hasAssignedAbilities(char)
@@ -211,17 +212,20 @@ func (s *CreationFlowServiceImpl) isStepComplete(char *character.Character, step
 
 // Helper methods for checking step completion
 func (s *CreationFlowServiceImpl) hasAssignedAbilities(char *character.Character) bool {
-	// Check if abilities are set to non-default values
-	if len(char.Attributes) < 6 {
+	// Check if all 6 ability scores have been assigned
+	if len(char.AbilityAssignments) != 6 {
 		return false
 	}
-	// For now, just check if any ability score is > 8 (default)
-	for _, attr := range char.Attributes {
-		if attr.Score > 8 {
-			return true
+
+	// Verify each ability has an assignment
+	requiredAbilities := []string{"STR", "DEX", "CON", "INT", "WIS", "CHA"}
+	for _, ability := range requiredAbilities {
+		if _, exists := char.AbilityAssignments[ability]; !exists {
+			return false
 		}
 	}
-	return false
+
+	return true
 }
 
 func (s *CreationFlowServiceImpl) hasCompletedDomainSkills(char *character.Character) bool {

--- a/internal/services/character/flow_builder.go
+++ b/internal/services/character/flow_builder.go
@@ -263,6 +263,8 @@ func (b *FlowBuilderImpl) buildClassSpecificSteps(ctx context.Context, char *cha
 		steps = append(steps, b.buildFighterSteps(ctx, char)...)
 	case "ranger":
 		steps = append(steps, b.buildRangerSteps(ctx, char)...)
+	case "wizard":
+		steps = append(steps, b.buildWizardSteps(ctx, char)...)
 		// Add other classes as needed
 	}
 

--- a/internal/services/character/flow_builder_wizard.go
+++ b/internal/services/character/flow_builder_wizard.go
@@ -1,0 +1,21 @@
+package character
+
+import (
+	"context"
+	"github.com/KirkDiggler/dnd-bot-discord/internal/domain/character"
+)
+
+// buildWizardSteps creates wizard-specific steps
+func (b *FlowBuilderImpl) buildWizardSteps(ctx context.Context, char *character.Character) []character.CreationStep {
+	var steps []character.CreationStep
+
+	// For now, return empty until we add spell selection step types
+	// TODO: Add spell selection when StepTypeSpellSelection is added to domain
+
+	// Future steps would include:
+	// 1. Cantrip selection (3 cantrips at level 1)
+	// 2. Spell selection (6 1st-level spells for spellbook)
+	// 3. Arcane tradition selection (at level 2)
+
+	return steps
+}


### PR DESCRIPTION
## Summary

This PR implements a comprehensive ability score assignment system for character creation with an improved UI that addresses Discord's interaction limitations.

## Key Features

### Roll-All-At-Once System
- Rolls all 6 ability scores simultaneously (4d6 drop lowest for each)
- Clean display format: **15** [6,5,4,~~2~~] without exposing internal IDs
- Shows total and average scores
- Displays racial bonuses that will be applied

### Smart Auto-Assignment
- Class-optimized ability assignments:
  - **Wizard**: INT > DEX > CON > WIS > CHA > STR
  - **Fighter**: STR > CON > DEX > WIS > CHA > INT
  - **Rogue**: DEX > CON > INT > WIS > CHA > STR
  - And more for each class

### Manual Assignment UI
- Button-per-ability interface (STR, DEX, CON, INT, WIS, CHA)
- Shows current assignments with racial bonuses
- Direct assignment using buttons instead of dropdown (works around Discord state limitations)
- Smart swapping when reassigning already-assigned scores

### Additional Improvements
- Fixed "Start Fresh" to reset current character instead of creating new one
- Fixed ability score completion checks in flow service (was checking Attributes instead of AbilityRolls)
- Added wizard to flow builder (spell selection TODO)
- Moved auto-assign button to correct step in the flow

## Technical Changes

### Discord Handler Updates
- New handlers for direct assignment and manual UI
- Fixed custom ID parsing to properly track target abilities
- Enhanced progress tracker with inline horizontal layout

### Flow Service Fixes
- StepTypeAbilityScores now checks AbilityRolls instead of Attributes
- hasAssignedAbilities now properly validates all 6 abilities are assigned
- Added wizard case to flow builder (currently returns empty steps pending spell selection implementation)

## Testing
The build passes and manual testing shows:
- ✅ Ability scores roll correctly
- ✅ Auto-assignment works based on class
- ✅ Manual assignment allows tweaking individual scores
- ✅ Start Fresh properly resets without creating new character
- ✅ Progress flows to next step after assignment

## Known Limitations
- Dropdown assignment has Discord state tracking limitations (addressed by using buttons)
- Individual rolling handlers exist but aren't offered as an option (can be added in future PR)
- Wizard spell selection steps need to be implemented

Fixes issues with ability score assignment flow and provides a much smoother user experience.