### PR TITLE
refactor: remove UIHints from flow service per ADR-002

### DIFF
--- a/internal/discord/v2/handlers/character_creation.go
+++ b/internal/discord/v2/handlers/character_creation.go
@@ -78,20 +78,6 @@ func (h *CharacterCreationHandler) registerStepHandlers() {
 	h.stepHandlers[domainCharacter.StepTypeEquipmentSelection] = h.handleEquipmentSelection
 	h.stepHandlers[domainCharacter.StepTypeCharacterDetails] = h.handleCharacterDetails
 
-	// Class-specific steps
-	h.stepHandlers[domainCharacter.StepTypeSkillSelection] = h.handleGenericSelection
-	h.stepHandlers[domainCharacter.StepTypeLanguageSelection] = h.handleGenericSelection
-	h.stepHandlers[domainCharacter.StepTypeFightingStyleSelection] = h.handleGenericSelection
-	h.stepHandlers[domainCharacter.StepTypeDivineDomainSelection] = h.handleGenericSelection
-	h.stepHandlers[domainCharacter.StepTypeFavoredEnemySelection] = h.handleGenericSelection
-	h.stepHandlers[domainCharacter.StepTypeNaturalExplorerSelection] = h.handleGenericSelection
-
-	// Spellcaster steps
-	h.stepHandlers[domainCharacter.StepTypeCantripsSelection] = h.handleSpellSelection
-	h.stepHandlers[domainCharacter.StepTypeSpellSelection] = h.handleSpellSelection
-	h.stepHandlers[domainCharacter.StepTypeSpellbookSelection] = h.handleSpellSelection
-	h.stepHandlers[domainCharacter.StepTypeSpellsKnownSelection] = h.handleSpellSelection
-
 	// Class specialization steps
 	h.stepHandlers[domainCharacter.StepTypeExpertiseSelection] = h.handleGenericSelection
 	h.stepHandlers[domainCharacter.StepTypeSubclassSelection] = h.handleGenericSelection
@@ -109,6 +95,8 @@ func (h *CharacterCreationHandler) registerStepHandlers() {
 	// Spellcaster steps
 	h.stepHandlers[domainCharacter.StepTypeCantripsSelection] = h.handleSpellSelection
 	h.stepHandlers[domainCharacter.StepTypeSpellSelection] = h.handleSpellSelection
+	h.stepHandlers[domainCharacter.StepTypeSpellbookSelection] = h.handleSpellSelection
+	h.stepHandlers[domainCharacter.StepTypeSpellsKnownSelection] = h.handleSpellSelection
 
 	// Final step
 	h.stepHandlers[domainCharacter.StepTypeComplete] = h.handleComplete

--- a/internal/discord/v2/handlers/character_creation.go
+++ b/internal/discord/v2/handlers/character_creation.go
@@ -79,6 +79,24 @@ func (h *CharacterCreationHandler) registerStepHandlers() {
 	h.stepHandlers[domainCharacter.StepTypeCharacterDetails] = h.handleCharacterDetails
 
 	// Class-specific steps
+	h.stepHandlers[domainCharacter.StepTypeSkillSelection] = h.handleGenericSelection
+	h.stepHandlers[domainCharacter.StepTypeLanguageSelection] = h.handleGenericSelection
+	h.stepHandlers[domainCharacter.StepTypeFightingStyleSelection] = h.handleGenericSelection
+	h.stepHandlers[domainCharacter.StepTypeDivineDomainSelection] = h.handleGenericSelection
+	h.stepHandlers[domainCharacter.StepTypeFavoredEnemySelection] = h.handleGenericSelection
+	h.stepHandlers[domainCharacter.StepTypeNaturalExplorerSelection] = h.handleGenericSelection
+
+	// Spellcaster steps
+	h.stepHandlers[domainCharacter.StepTypeCantripsSelection] = h.handleSpellSelection
+	h.stepHandlers[domainCharacter.StepTypeSpellSelection] = h.handleSpellSelection
+	h.stepHandlers[domainCharacter.StepTypeSpellbookSelection] = h.handleSpellSelection
+	h.stepHandlers[domainCharacter.StepTypeSpellsKnownSelection] = h.handleSpellSelection
+
+	// Class specialization steps
+	h.stepHandlers[domainCharacter.StepTypeExpertiseSelection] = h.handleGenericSelection
+	h.stepHandlers[domainCharacter.StepTypeSubclassSelection] = h.handleGenericSelection
+
+	// Class-specific steps
 	h.stepHandlers[domainCharacter.StepTypeFightingStyleSelection] = h.handleFightingStyleSelection
 	h.stepHandlers[domainCharacter.StepTypeDivineDomainSelection] = h.handleDivineDomainSelection
 	h.stepHandlers[domainCharacter.StepTypeFavoredEnemySelection] = h.handleFavoredEnemySelection
@@ -162,6 +180,12 @@ func (h *CharacterCreationHandler) handleSkillSelection(char *domainCharacter.Ch
 func (h *CharacterCreationHandler) handleLanguageSelection(char *domainCharacter.Character, step *domainCharacter.CreationStep) (*core.Response, error) {
 	// TODO: Implement language selection UI
 	return nil, fmt.Errorf("language selection UI not implemented")
+}
+
+func (h *CharacterCreationHandler) handleGenericSelection(char *domainCharacter.Character, step *domainCharacter.CreationStep) (*core.Response, error) {
+	// Generic handler for simple selection steps
+	// The enhanced handler will provide the actual UI
+	return h.buildEnhancedStepResponse(char, step)
 }
 
 func (h *CharacterCreationHandler) handleSpellSelection(char *domainCharacter.Character, step *domainCharacter.CreationStep) (*core.Response, error) {

--- a/internal/discord/v2/handlers/character_creation_enhanced.go
+++ b/internal/discord/v2/handlers/character_creation_enhanced.go
@@ -197,6 +197,11 @@ func (h *CharacterCreationHandler) buildEnhancedStepResponse(char *domainCharact
 		embed.Description(step.Description)
 		h.buildSelectMenuFromOptions(components, step, char.ID, "subclass")
 
+	case domainCharacter.StepTypeCantripsSelection, domainCharacter.StepTypeSpellSelection, domainCharacter.StepTypeSpellbookSelection, domainCharacter.StepTypeSpellsKnownSelection:
+		// These require pagination due to large number of options
+		embed.Description(step.Description)
+		components.PrimaryButton("📜 Browse Spell List", "open_spell_selection", char.ID)
+
 	default:
 		// Handle any custom step types
 		embed.Description(fmt.Sprintf("Step type %s is not yet implemented", step.Type))

--- a/internal/discord/v2/routers/create.go
+++ b/internal/discord/v2/routers/create.go
@@ -145,6 +145,16 @@ func (r *CreateRouter) registerRoutes() {
 	r.router.ComponentFunc("select_equipment", r.creationHandler.HandleSelectEquipment)
 	r.router.ComponentFunc("confirm_equipment_selection", r.creationHandler.HandleConfirmEquipmentSelection)
 
+	// Class-specific selection handlers
+	r.router.ComponentFunc("skill", r.creationHandler.HandleStepSelection)
+	r.router.ComponentFunc("language", r.creationHandler.HandleStepSelection)
+	r.router.ComponentFunc("fighting_style", r.creationHandler.HandleStepSelection)
+	r.router.ComponentFunc("divine_domain", r.creationHandler.HandleStepSelection)
+	r.router.ComponentFunc("favored_enemy", r.creationHandler.HandleStepSelection)
+	r.router.ComponentFunc("natural_explorer", r.creationHandler.HandleStepSelection)
+	r.router.ComponentFunc("expertise", r.creationHandler.HandleStepSelection)
+	r.router.ComponentFunc("subclass", r.creationHandler.HandleStepSelection)
+
 	// Future: /dnd create encounter, /dnd create item, etc.
 	// r.router.ActionFunc("encounter", r.handleCreateEncounter)
 	// r.router.ActionFunc("item", r.handleCreateItem)

--- a/internal/domain/rulebook/dnd5e/character_creation_steps.go
+++ b/internal/domain/rulebook/dnd5e/character_creation_steps.go
@@ -24,6 +24,12 @@ var CharacterCreationSteps = []string{
 	// Spellcaster steps
 	"cantrips_selection",
 	"spell_selection",
+	"spellbook_selection",
+	"spells_known_selection",
+
+	// Class specialization steps
+	"expertise_selection",
+	"subclass_selection",
 
 	// Final step
 	"complete",

--- a/internal/services/character/flow_builder_spellcasters.go
+++ b/internal/services/character/flow_builder_spellcasters.go
@@ -17,19 +17,6 @@ func (b *FlowBuilderImpl) buildBardSteps(ctx context.Context, char *character.Ch
 		MinChoices:  2,
 		MaxChoices:  2,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Actions: []character.StepAction{
-				{
-					ID:    "select_expertise",
-					Label: "Choose Skills",
-					Style: "primary",
-					Icon:  "⭐",
-				},
-			},
-			Layout:       "list",
-			ShowProgress: true,
-			Color:        0xA855F7, // Purple for bards
-		},
 	})
 
 	// Cantrip selection (2 cantrips)
@@ -40,11 +27,6 @@ func (b *FlowBuilderImpl) buildBardSteps(ctx context.Context, char *character.Ch
 		MinChoices:  2,
 		MaxChoices:  2,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Layout:          "grid",
-			ShowRecommended: true,
-			Color:           0xA855F7,
-		},
 	}
 
 	// Populate cantrips options from D&D API
@@ -66,28 +48,6 @@ func (b *FlowBuilderImpl) buildBardSteps(ctx context.Context, char *character.Ch
 		MinChoices:  4,
 		MaxChoices:  4,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Actions: []character.StepAction{
-				{
-					ID:    "select_spells",
-					Label: "Choose Spells",
-					Style: "primary",
-					Icon:  "🎵",
-				},
-				{
-					ID:          "quick_build",
-					Label:       "Suggested Spells",
-					Style:       "secondary",
-					Icon:        "💡",
-					Description: "Popular bard spell choices",
-				},
-			},
-			Layout:          "list",
-			ShowProgress:    true,
-			ProgressFormat:  "%d/%d spells selected",
-			ShowRecommended: true,
-			Color:           0xA855F7,
-		},
 	}
 
 	// Populate spell options from D&D API
@@ -119,11 +79,6 @@ func (b *FlowBuilderImpl) buildDruidSteps(ctx context.Context, char *character.C
 		MinChoices:  2,
 		MaxChoices:  2,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Layout:          "grid",
-			ShowRecommended: true,
-			Color:           0x10B981, // Green for druids
-		},
 	}
 
 	// Populate cantrips options from D&D API
@@ -157,19 +112,6 @@ func (b *FlowBuilderImpl) buildRogueSteps(ctx context.Context, char *character.C
 		MinChoices:  2,
 		MaxChoices:  2,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Actions: []character.StepAction{
-				{
-					ID:    "select_expertise",
-					Label: "Choose Skills",
-					Style: "primary",
-					Icon:  "🗡️",
-				},
-			},
-			Layout:       "list",
-			ShowProgress: true,
-			Color:        0x64748B, // Gray for rogues
-		},
 	})
 
 	// Thieves' Cant is automatic, no choice needed
@@ -189,18 +131,6 @@ func (b *FlowBuilderImpl) buildSorcererSteps(ctx context.Context, char *characte
 		MinChoices:  1,
 		MaxChoices:  1,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Actions: []character.StepAction{
-				{
-					ID:    "select_origin",
-					Label: "Choose Origin",
-					Style: "primary",
-					Icon:  "🔥",
-				},
-			},
-			Layout: "grid",
-			Color:  0xDC2626, // Red for sorcerers
-		},
 	})
 
 	// Cantrip selection (4 cantrips)
@@ -211,11 +141,6 @@ func (b *FlowBuilderImpl) buildSorcererSteps(ctx context.Context, char *characte
 		MinChoices:  4,
 		MaxChoices:  4,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Layout:          "grid",
-			ShowRecommended: true,
-			Color:           0xDC2626,
-		},
 	}
 
 	// Populate cantrips options from D&D API
@@ -237,21 +162,6 @@ func (b *FlowBuilderImpl) buildSorcererSteps(ctx context.Context, char *characte
 		MinChoices:  2,
 		MaxChoices:  2,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Actions: []character.StepAction{
-				{
-					ID:    "select_spells",
-					Label: "Choose Spells",
-					Style: "primary",
-					Icon:  "🔮",
-				},
-			},
-			Layout:          "list",
-			ShowProgress:    true,
-			ProgressFormat:  "%d/%d spells selected",
-			ShowRecommended: true,
-			Color:           0xDC2626,
-		},
 	}
 
 	// Populate spell options from D&D API
@@ -283,18 +193,6 @@ func (b *FlowBuilderImpl) buildWarlockSteps(ctx context.Context, char *character
 		MinChoices:  1,
 		MaxChoices:  1,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Actions: []character.StepAction{
-				{
-					ID:    "select_patron",
-					Label: "Choose Patron",
-					Style: "primary",
-					Icon:  "👁️",
-				},
-			},
-			Layout: "grid",
-			Color:  0x7C3AED, // Dark purple for warlocks
-		},
 	})
 
 	// Cantrip selection (2 cantrips)
@@ -305,11 +203,6 @@ func (b *FlowBuilderImpl) buildWarlockSteps(ctx context.Context, char *character
 		MinChoices:  2,
 		MaxChoices:  2,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Layout:          "grid",
-			ShowRecommended: true,
-			Color:           0x7C3AED,
-		},
 	}
 
 	// Populate cantrips options from D&D API
@@ -331,21 +224,6 @@ func (b *FlowBuilderImpl) buildWarlockSteps(ctx context.Context, char *character
 		MinChoices:  2,
 		MaxChoices:  2,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Actions: []character.StepAction{
-				{
-					ID:    "select_spells",
-					Label: "Choose Spells",
-					Style: "primary",
-					Icon:  "📜",
-				},
-			},
-			Layout:          "list",
-			ShowProgress:    true,
-			ProgressFormat:  "%d/%d spells selected",
-			ShowRecommended: true,
-			Color:           0x7C3AED,
-		},
 	}
 
 	// Populate spell options from D&D API

--- a/internal/services/character/flow_builder_wizard.go
+++ b/internal/services/character/flow_builder_wizard.go
@@ -17,25 +17,6 @@ func (b *FlowBuilderImpl) buildWizardSteps(ctx context.Context, char *character.
 		MinChoices:  3,
 		MaxChoices:  3,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Actions: []character.StepAction{
-				{
-					ID:    "open_spell_selection",
-					Label: "Browse Cantrips",
-					Style: "primary",
-					Icon:  "✨",
-				},
-				{
-					ID:    "suggested_cantrips",
-					Label: "Use Suggested",
-					Style: "secondary",
-					Icon:  "💡",
-				},
-			},
-			Layout:          "grid",
-			ShowRecommended: true,
-			Color:           0x6B46C1, // Purple for arcane
-		},
 	}
 
 	// Fetch wizard cantrips from D&D API
@@ -62,28 +43,6 @@ func (b *FlowBuilderImpl) buildWizardSteps(ctx context.Context, char *character.
 		MinChoices:  6,
 		MaxChoices:  6,
 		Required:    true,
-		UIHints: &character.StepUIHints{
-			Actions: []character.StepAction{
-				{
-					ID:    "open_spell_selection",
-					Label: "Browse Spell List",
-					Style: "primary",
-					Icon:  "📜",
-				},
-				{
-					ID:          "quick_build",
-					Label:       "Quick Build",
-					Style:       "secondary",
-					Icon:        "⚡",
-					Description: "Recommended spell selection",
-				},
-			},
-			Layout:          "list",
-			ShowProgress:    true,
-			ProgressFormat:  "%d/%d spells selected",
-			ShowRecommended: true,
-			Color:           0x6B46C1,
-		},
 	}
 
 	// Fetch wizard 1st level spells from D&D API
@@ -113,18 +72,6 @@ func (b *FlowBuilderImpl) buildWizardSteps(ctx context.Context, char *character.
 			MinChoices:  1,
 			MaxChoices:  1,
 			Required:    true,
-			UIHints: &character.StepUIHints{
-				Actions: []character.StepAction{
-					{
-						ID:    "select_tradition",
-						Label: "Choose Tradition",
-						Style: "primary",
-						Icon:  "🔮",
-					},
-				},
-				Layout: "grid",
-				Color:  0x6B46C1,
-			},
 		})
 	}
 

--- a/internal/services/character/ranger_draft_proficiency_test.go
+++ b/internal/services/character/ranger_draft_proficiency_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/KirkDiggler/dnd-bot-discord/internal/clients/dnd5e"
+	draftrepo "github.com/KirkDiggler/dnd-bot-discord/internal/repositories/character_draft"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/repositories/characters"
 	"github.com/KirkDiggler/dnd-bot-discord/internal/services/character"
 	"github.com/stretchr/testify/assert"
@@ -32,10 +33,14 @@ func TestRangerDraftFinalization_MissingProficiencies(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Create draft repository
+	draftRepo := draftrepo.NewInMemoryRepository()
+
 	// Create service
 	svc := character.NewService(&character.ServiceConfig{
-		DNDClient:  client,
-		Repository: repo,
+		DNDClient:       client,
+		Repository:      repo,
+		DraftRepository: draftRepo,
 	})
 
 	// Simulate the draft creation flow


### PR DESCRIPTION
## Summary
This PR removes the UIHints pattern from the character creation flow service and implements proper explicit step handlers in the Discord handler layer, as required by ADR-002.

## What Changed

**Removed UIHints from Flow Service:**
- Deleted all `UIHints` field assignments in flow builder methods (wizard, spellcasters, etc.)
- Removed the check for `step.UIHints` in `buildEnhancedStepResponse`
- Deleted the `buildUIHintsResponse` method entirely

**Added Explicit Step Handlers:**
- Implemented handlers for all class-specific steps:
  - Skill, language, fighting style, divine domain selections  
  - Favored enemy, natural explorer, expertise, subclass selections
- Added spell-related handlers for cantrips and spell selection
- Created `handleGenericSelection` for simple selection steps
- Added `buildSelectMenuFromOptions` helper method

**Router Updates:**
- Registered all new step action handlers in the create router
- Each step type now has its own route (e.g., "skill", "language", "fighting_style")

## Why This Change

As documented in ADR-002, the UIHints pattern violated separation of concerns by having the service layer dictate UI decisions. This refactor establishes proper boundaries:

- **Flow Service**: Manages business logic, step progression, and validation
- **Discord Handlers**: Own all UI rendering decisions and Discord-specific interactions  
- **No UI Leakage**: Service layer has no knowledge of buttons, colors, or layouts

The principle: "Rulebooks define WHAT, Discord defines HOW"

## Testing
- All existing character creation flows continue to work
- Fixed failing test by adding missing draft repository dependency
- All pre-commit checks pass (lint, tests, build)

## Technical Debt Addressed
This completes the work started in PR #314 to properly follow ADR specifications. The system is now more maintainable with clear separation of concerns.

Fixes #314